### PR TITLE
chore: ignore .vite/ build cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 dist/
+.vite/
 playwright-report/
 test-results/
 .claude/skills/spaced-learning-guide-workspace/


### PR DESCRIPTION
Adds `.vite/` to `.gitignore` — it's Vite's local build cache and shouldn't be tracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)