### PR TITLE
feat: undo card/deck deletion + confirmation before deleting decks

### DIFF
--- a/src/components/CardList.tsx
+++ b/src/components/CardList.tsx
@@ -1,10 +1,44 @@
+import { useState, useEffect } from 'react'
 import { useCards } from '../hooks/useCards'
-import { deleteCard } from '../db/cardRepo'
+import { deleteCard, getCardSnapshot, restoreCard } from '../db/cardRepo'
+import type { Card } from '../domain/types'
+import type { ScheduleRecord } from '../db/db'
+
+interface UndoState {
+  card: Card
+  schedule: ScheduleRecord | undefined
+  timeoutId: ReturnType<typeof setTimeout>
+}
 
 export const CardList = () => {
   const cards = useCards()
+  const [undo, setUndo] = useState<UndoState | null>(null)
 
-  if (cards.length === 0) {
+  useEffect(() => {
+    return () => {
+      if (undo) clearTimeout(undo.timeoutId)
+    }
+  }, [undo])
+
+  const handleDelete = async (id: string) => {
+    if (undo) {
+      clearTimeout(undo.timeoutId)
+      setUndo(null)
+    }
+    const snapshot = await getCardSnapshot(id)
+    await deleteCard(id)
+    const timeoutId = setTimeout(() => setUndo(null), 5000)
+    setUndo({ ...snapshot, timeoutId })
+  }
+
+  const handleUndo = async () => {
+    if (!undo) return
+    clearTimeout(undo.timeoutId)
+    await restoreCard(undo.card, undo.schedule)
+    setUndo(null)
+  }
+
+  if (cards.length === 0 && !undo) {
     return <p>No cards yet. Add some!</p>
   }
 
@@ -28,7 +62,7 @@ export const CardList = () => {
               <span style={{ color: '#888', marginLeft: '8px' }}>→ {card.back}</span>
             </div>
             <button
-              onClick={() => deleteCard(card.id)}
+              onClick={() => handleDelete(card.id)}
               aria-label={`Delete card: ${card.front}`}
               style={{ background: 'none', border: '1px solid #555', cursor: 'pointer', padding: '4px 8px' }}
             >
@@ -37,6 +71,33 @@ export const CardList = () => {
           </li>
         ))}
       </ul>
+
+      {undo && (
+        <div
+          style={{
+            position: 'fixed',
+            bottom: '24px',
+            left: '50%',
+            transform: 'translateX(-50%)',
+            background: '#2a2a3e',
+            border: '1px solid #444',
+            borderRadius: '8px',
+            padding: '12px 16px',
+            display: 'flex',
+            alignItems: 'center',
+            gap: '12px',
+            zIndex: 1000,
+          }}
+        >
+          <span>Card deleted</span>
+          <button
+            onClick={handleUndo}
+            style={{ padding: '4px 12px', cursor: 'pointer', borderRadius: '4px' }}
+          >
+            Undo
+          </button>
+        </div>
+      )}
     </div>
   )
 }

--- a/src/components/DeckList.tsx
+++ b/src/components/DeckList.tsx
@@ -1,16 +1,33 @@
-import { useState, type FormEvent } from 'react'
+import { useState, useEffect, type FormEvent } from 'react'
 import { createDeck, DeckValidationError } from '../domain/decks'
-import { addDeck, deleteDeck } from '../db/deckRepo'
+import { addDeck, deleteDeck, getDeckSnapshot, restoreDeck } from '../db/deckRepo'
 import { useDeckStats } from '../hooks/useDecks'
+import type { Card, Deck } from '../domain/types'
+import type { ScheduleRecord } from '../db/db'
 
 interface Props {
   readonly onReviewDeck: (deckId: string, deckName: string) => void
+}
+
+interface UndoState {
+  deck: Deck
+  cards: Card[]
+  schedules: ScheduleRecord[]
+  timeoutId: ReturnType<typeof setTimeout>
 }
 
 export const DeckList = ({ onReviewDeck }: Props) => {
   const deckStats = useDeckStats()
   const [newName, setNewName] = useState('')
   const [error, setError] = useState('')
+  const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null)
+  const [undo, setUndo] = useState<UndoState | null>(null)
+
+  useEffect(() => {
+    return () => {
+      if (undo) clearTimeout(undo.timeoutId)
+    }
+  }, [undo])
 
   const handleAdd = async (e: FormEvent) => {
     e.preventDefault()
@@ -22,6 +39,33 @@ export const DeckList = ({ onReviewDeck }: Props) => {
       setError(err instanceof DeckValidationError ? err.message : 'Failed to create deck')
     }
   }
+
+  const handleConfirmDelete = async () => {
+    if (!pendingDeleteId) return
+    const id = pendingDeleteId
+    setPendingDeleteId(null)
+
+    if (undo) {
+      clearTimeout(undo.timeoutId)
+      setUndo(null)
+    }
+
+    const snapshot = await getDeckSnapshot(id)
+    await deleteDeck(id)
+    const timeoutId = setTimeout(() => setUndo(null), 5000)
+    setUndo({ ...snapshot, timeoutId })
+  }
+
+  const handleUndo = async () => {
+    if (!undo) return
+    clearTimeout(undo.timeoutId)
+    await restoreDeck(undo.deck, undo.cards, undo.schedules)
+    setUndo(null)
+  }
+
+  const pendingDeck = pendingDeleteId
+    ? deckStats.find((s) => s.deck.id === pendingDeleteId)
+    : undefined
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
@@ -81,7 +125,7 @@ export const DeckList = ({ onReviewDeck }: Props) => {
                 Review
               </button>
               <button
-                onClick={() => deleteDeck(deck.id)}
+                onClick={() => setPendingDeleteId(deck.id)}
                 aria-label={`Delete deck ${deck.name}`}
                 style={{ background: 'none', border: '1px solid #555', borderRadius: '4px', padding: '6px 10px', cursor: 'pointer', color: '#aaa' }}
               >
@@ -90,6 +134,68 @@ export const DeckList = ({ onReviewDeck }: Props) => {
             </li>
           ))}
         </ul>
+      )}
+
+      {pendingDeck && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-label={`Confirm deleting ${pendingDeck.deck.name}`}
+          style={{
+            position: 'fixed',
+            inset: 0,
+            background: 'rgba(0,0,0,0.6)',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            zIndex: 1000,
+          }}
+        >
+          <div style={{ background: '#1e1e2e', borderRadius: '12px', padding: '24px', maxWidth: '360px', width: '90%' }}>
+            <p style={{ margin: '0 0 8px', fontWeight: 'bold' }}>Delete &ldquo;{pendingDeck.deck.name}&rdquo;?</p>
+            <p style={{ margin: '0 0 20px', color: '#888', fontSize: '0.9rem' }}>
+              This will delete {pendingDeck.totalCount} card{pendingDeck.totalCount !== 1 ? 's' : ''} and all review history.
+            </p>
+            <div style={{ display: 'flex', gap: '8px', justifyContent: 'flex-end' }}>
+              <button onClick={() => setPendingDeleteId(null)} style={{ padding: '8px 16px', cursor: 'pointer' }}>
+                Cancel
+              </button>
+              <button
+                onClick={handleConfirmDelete}
+                style={{ padding: '8px 16px', cursor: 'pointer', background: '#c0392b', border: 'none', borderRadius: '4px', color: '#fff' }}
+              >
+                Delete
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {undo && (
+        <div
+          style={{
+            position: 'fixed',
+            bottom: '24px',
+            left: '50%',
+            transform: 'translateX(-50%)',
+            background: '#2a2a3e',
+            border: '1px solid #444',
+            borderRadius: '8px',
+            padding: '12px 16px',
+            display: 'flex',
+            alignItems: 'center',
+            gap: '12px',
+            zIndex: 1000,
+          }}
+        >
+          <span>Deck deleted</span>
+          <button
+            onClick={handleUndo}
+            style={{ padding: '4px 12px', cursor: 'pointer', borderRadius: '4px' }}
+          >
+            Undo
+          </button>
+        </div>
       )}
     </div>
   )

--- a/src/db/cardRepo.ts
+++ b/src/db/cardRepo.ts
@@ -1,4 +1,4 @@
-import { db } from './db'
+import { db, type ScheduleRecord } from './db'
 import type { Card } from '../domain/types'
 
 export const addCard = (card: Card): Promise<string> => db.cards.add(card)
@@ -13,5 +13,21 @@ export const deleteCard = async (id: string): Promise<void> => {
   await db.transaction('rw', db.cards, db.schedules, async () => {
     await db.cards.delete(id)
     await db.schedules.delete(id)
+  })
+}
+
+/** Captures card + its schedule record before deletion, for undo. */
+export const getCardSnapshot = async (id: string): Promise<{ card: Card; schedule: ScheduleRecord | undefined }> => {
+  const card = await db.cards.get(id)
+  if (!card) throw new Error(`Card ${id} not found`)
+  const schedule = await db.schedules.get(id)
+  return { card, schedule }
+}
+
+/** Re-inserts a previously deleted card and its schedule. */
+export const restoreCard = async (card: Card, schedule: ScheduleRecord | undefined): Promise<void> => {
+  await db.transaction('rw', db.cards, db.schedules, async () => {
+    await db.cards.put(card)
+    if (schedule) await db.schedules.put(schedule)
   })
 }

--- a/src/db/deckRepo.ts
+++ b/src/db/deckRepo.ts
@@ -1,5 +1,5 @@
-import { db } from './db'
-import type { Deck } from '../domain/types'
+import { db, type ScheduleRecord } from './db'
+import type { Card, Deck } from '../domain/types'
 import { createCard } from '../domain/cards'
 import { VIETNAMESE_SEED_CARDS } from './seedData'
 
@@ -15,6 +15,25 @@ export const deleteDeck = async (id: string): Promise<void> => {
     await db.schedules.bulkDelete(cardIds)
     await db.cards.where('deckId').equals(id).delete()
     await db.decks.delete(id)
+  })
+}
+
+/** Captures deck + all its cards + their schedules before deletion, for undo. */
+export const getDeckSnapshot = async (id: string): Promise<{ deck: Deck; cards: Card[]; schedules: ScheduleRecord[] }> => {
+  const deck = await db.decks.get(id)
+  if (!deck) throw new Error(`Deck ${id} not found`)
+  const cards = await db.cards.where('deckId').equals(id).toArray()
+  const scheduleOrUndefined = await db.schedules.bulkGet(cards.map((c) => c.id))
+  const schedules = scheduleOrUndefined.filter((s): s is ScheduleRecord => s !== undefined)
+  return { deck, cards, schedules }
+}
+
+/** Re-inserts a previously deleted deck with all its cards and schedules. */
+export const restoreDeck = async (deck: Deck, cards: Card[], schedules: ScheduleRecord[]): Promise<void> => {
+  await db.transaction('rw', db.decks, db.cards, db.schedules, async () => {
+    await db.decks.put(deck)
+    await db.cards.bulkPut(cards)
+    if (schedules.length > 0) await db.schedules.bulkPut(schedules)
   })
 }
 

--- a/tests/e2e/flashcards.spec.ts
+++ b/tests/e2e/flashcards.spec.ts
@@ -57,6 +57,57 @@ test.describe('Flashcard app', () => {
     await expect(page.getByRole('alert')).toBeVisible()
   })
 
+  test('delete a card then undo restores it', async ({ page }) => {
+    await page.getByRole('button', { name: 'Add', exact: true }).click()
+    await page.getByLabel('Front').fill('Capital of Japan')
+    await page.getByLabel('Back').fill('Tokyo')
+    await page.getByRole('button', { name: 'Add Card' }).click()
+
+    await page.getByRole('button', { name: 'Cards' }).click()
+    await expect(page.getByText('Capital of Japan')).toBeVisible()
+
+    await page.getByRole('button', { name: 'Delete card: Capital of Japan' }).click()
+    await expect(page.getByText('Capital of Japan')).not.toBeVisible()
+
+    await page.getByRole('button', { name: 'Undo' }).click()
+    await expect(page.getByText('Capital of Japan')).toBeVisible()
+  })
+
+  test('delete a deck requires confirmation and cancel keeps it', async ({ page }) => {
+    await page.getByRole('button', { name: 'Decks' }).click()
+    await page.getByLabel('Deck name').fill('History')
+    await page.getByRole('button', { name: 'Add Deck' }).click()
+
+    await page.locator('li').filter({ hasText: 'History' }).getByRole('button', { name: /delete deck history/i }).click()
+    await expect(page.getByRole('dialog')).toBeVisible()
+
+    await page.getByRole('button', { name: 'Cancel' }).click()
+    await expect(page.getByText('History')).toBeVisible()
+  })
+
+  test('delete a deck then undo restores it', async ({ page }) => {
+    await page.getByRole('button', { name: 'Decks' }).click()
+    await page.getByLabel('Deck name').fill('Geography')
+    await page.getByRole('button', { name: 'Add Deck' }).click()
+
+    // Add a card to the deck
+    await page.getByRole('button', { name: 'Add', exact: true }).click()
+    await page.getByLabel('Deck').selectOption({ label: 'Geography' })
+    await page.getByLabel('Front').fill('Largest country by area')
+    await page.getByLabel('Back').fill('Russia')
+    await page.getByRole('button', { name: 'Add Card' }).click()
+
+    // Delete the deck (confirm)
+    await page.getByRole('button', { name: 'Decks' }).click()
+    await page.locator('li').filter({ hasText: 'Geography' }).getByRole('button', { name: /delete deck geography/i }).click()
+    await page.getByRole('dialog').getByRole('button', { name: 'Delete' }).click()
+    await expect(page.getByText('Geography')).not.toBeVisible()
+
+    // Undo — deck and card come back
+    await page.getByRole('button', { name: 'Undo' }).click()
+    await expect(page.getByText('Geography')).toBeVisible()
+  })
+
   test('create a deck and review only its cards', async ({ page }) => {
     // Create a second deck
     await page.getByRole('button', { name: 'Decks' }).click()


### PR DESCRIPTION
## Summary
- Deleting a card shows a 5-second undo toast; Undo re-inserts the card and its review schedule
- Deleting a deck first shows a confirmation dialog with the card count; after confirming, a 5-second undo toast lets you restore the deck with all cards and schedules intact
- New repo helpers: `getCardSnapshot`/`restoreCard` (cardRepo), `getDeckSnapshot`/`restoreDeck` (deckRepo)

## Test plan
- [ ] Unit tests pass (`npx vitest run tests/unit`)
- [ ] E2E tests pass (`npx playwright test`) — 3 new tests covering card undo, deck cancel, deck undo
- [ ] Type-check clean (`npx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)