### PR TITLE
fix: Review button disabled for decks with unreviewed cards

### DIFF
--- a/src/hooks/useDecks.ts
+++ b/src/hooks/useDecks.ts
@@ -13,13 +13,16 @@ export const useDeckStats = (): DeckStats[] =>
     async () => {
       const decks = await db.decks.orderBy('createdAt').toArray()
       const now = Date.now()
-      const dueRecords = await db.schedules.where('due').belowOrEqual(now).toArray()
-      const dueCardIdSet = new Set(dueRecords.map((r) => r.cardId))
 
       return Promise.all(
         decks.map(async (deck) => {
           const deckCards = await db.cards.where('deckId').equals(deck.id).toArray()
-          const dueCount = deckCards.filter((c) => dueCardIdSet.has(c.id)).length
+          const schedules = await db.schedules.bulkGet(deckCards.map((c) => c.id))
+          // Cards with no schedule are new — always due. Cards with a schedule are due if due <= now.
+          const dueCount = deckCards.filter((_, i) => {
+            const s = schedules[i]
+            return !s || s.due <= now
+          }).length
           return { deck, dueCount, totalCount: deckCards.length }
         }),
       )

--- a/tests/e2e/flashcards.spec.ts
+++ b/tests/e2e/flashcards.spec.ts
@@ -108,6 +108,16 @@ test.describe('Flashcard app', () => {
     await expect(page.getByText('Geography')).toBeVisible()
   })
 
+  test('Review button is enabled for deck with unscheduled cards', async ({ page }) => {
+    // The seed deck has 1000 cards, none reviewed (no schedule entries)
+    // The Review button must be enabled because unscheduled cards are immediately due
+    await page.getByRole('button', { name: 'Decks' }).click()
+    const seedDeckRow = page.locator('li').filter({ hasText: '1000 most common words in Vietnamese' }).first()
+    await expect(seedDeckRow).toBeVisible()
+    const reviewBtn = seedDeckRow.getByRole('button', { name: 'Review' })
+    await expect(reviewBtn).not.toBeDisabled()
+  })
+
   test('create a deck and review only its cards', async ({ page }) => {
     // Create a second deck
     await page.getByRole('button', { name: 'Decks' }).click()


### PR DESCRIPTION
## Summary
- \`useDeckStats\` was computing \`dueCount\` only from schedule records where \`due <= now\`, ignoring cards with no schedule entry at all
- New/unscheduled cards (like the 1000 auto-seeded Vietnamese cards) are never in the schedules table, so their deck showed \`dueCount = 0\` and the Review button was disabled
- Fixed by using \`bulkGet\` per deck (matching the logic in \`getDueCardsByDeck\`): a card with no schedule is always due

## Test plan
- [x] New E2E test: "Review button is enabled for deck with unscheduled cards" — verifies seed deck Review button is not disabled
- [x] All 8 E2E tests pass (\`npx playwright test\`)
- [x] All 17 unit tests pass (\`npx vitest run tests/unit\`)
- [x] Type-check clean (\`npx tsc --noEmit\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)