### PR TITLE
fix: prevent double default deck on dev reload

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A flashcard app powered by the [FSRS](https://github.com/open-spaced-repetition/fsrs4anki/wiki/The-Algorithm) (Free Spaced Repetition Scheduler) algorithm.",
   "private": true,
   "scripts": {
-    "dev": "vite",
+    "dev": "fuser -k 5173/tcp 2>/dev/null; vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
     "test": "vitest run",

--- a/src/db/deckRepo.ts
+++ b/src/db/deckRepo.ts
@@ -37,21 +37,23 @@ export const restoreDeck = async (deck: Deck, cards: Card[], schedules: Schedule
   })
 }
 
+export const DEFAULT_DECK_ID = 'default-vietnamese-deck'
+
 // Seeds the Vietnamese vocabulary deck on fresh installs — called on app startup.
+// Uses a fixed ID so concurrent calls (e.g. React StrictMode double-invoke) are idempotent.
 export const ensureDefaultDeck = async (): Promise<void> => {
-  const count = await db.decks.count()
-  if (count === 0) {
+  await db.transaction('rw', db.decks, db.cards, async () => {
+    const existing = await db.decks.get(DEFAULT_DECK_ID)
+    if (existing) return
     const deck: Deck = {
-      id: crypto.randomUUID(),
+      id: DEFAULT_DECK_ID,
       name: '1000 most common words in Vietnamese',
       createdAt: Date.now(),
     }
-    await db.transaction('rw', db.decks, db.cards, async () => {
-      await db.decks.add(deck)
-      const cards = VIETNAMESE_SEED_CARDS.map(({ front, back }) =>
-        createCard(front, back, deck.id),
-      )
-      await db.cards.bulkAdd(cards)
-    })
-  }
+    await db.decks.put(deck)
+    const cards = VIETNAMESE_SEED_CARDS.map(({ front, back }) =>
+      createCard(front, back, deck.id),
+    )
+    await db.cards.bulkAdd(cards)
+  })
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,7 @@ import { VitePWA } from 'vite-plugin-pwa'
 
 export default defineConfig({
   base: '/spaced-learning/',
+  server: { port: 5173, strictPort: true },
   plugins: [
     react(),
     VitePWA({


### PR DESCRIPTION
## Summary
- React StrictMode double-invokes effects in dev; both `ensureDefaultDeck()` calls raced past the `count === 0` guard before either wrote, inserting the deck twice
- Fix: use a fixed stable deck ID (`DEFAULT_DECK_ID`) and move the existence check inside a serialized Dexie transaction — concurrent calls are now idempotent
- Also pin the Vite dev server to port 5173 with `strictPort: true` and kill it before starting, preventing port drift from orphaned processes

## Test plan
- [x] Unit tests pass (`npx vitest run tests/unit`)
- [x] E2E tests pass (`npx playwright test`)
- [x] Type-check clean (`npx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)