### PR TITLE
feat: keyboard shortcuts in review + success toast on add card

### DIFF
--- a/src/components/AddCardForm.tsx
+++ b/src/components/AddCardForm.tsx
@@ -1,4 +1,4 @@
-import { useState, type FormEvent } from 'react'
+import { useState, useEffect, useRef, type FormEvent } from 'react'
 import { createCard } from '../domain/cards'
 import { addCard } from '../db/cardRepo'
 import { upsertSchedule } from '../db/reviewRepo'
@@ -11,6 +11,14 @@ export const AddCardForm = () => {
   const [back, setBack] = useState('')
   const [deckId, setDeckId] = useState('')
   const [error, setError] = useState('')
+  const [success, setSuccess] = useState(false)
+  const successTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    return () => {
+      if (successTimer.current) clearTimeout(successTimer.current)
+    }
+  }, [])
 
   // Default to the first deck when decks load
   const selectedDeckId = deckId || decks[0]?.id || ''
@@ -28,6 +36,9 @@ export const AddCardForm = () => {
       await upsertSchedule(card.id, createNewSchedule())
       setFront('')
       setBack('')
+      setSuccess(true)
+      if (successTimer.current) clearTimeout(successTimer.current)
+      successTimer.current = setTimeout(() => setSuccess(false), 3000)
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to add card')
     }
@@ -37,6 +48,7 @@ export const AddCardForm = () => {
     <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
       <h2>Add Card</h2>
       {error && <p style={{ color: 'red' }} role="alert">{error}</p>}
+      {success && <p style={{ color: '#27ae60' }} role="status">Card added!</p>}
       <label>
         Deck
         <select

--- a/src/components/ReviewSession.tsx
+++ b/src/components/ReviewSession.tsx
@@ -1,12 +1,13 @@
+import { useEffect, useRef } from 'react'
 import { useReview } from '../hooks/useReview'
 import { useReviewedToday } from '../hooks/useReviewedToday'
 import type { Rating } from '../domain/types'
 
-const RATINGS: { label: string; value: Rating; color: string }[] = [
-  { label: 'Again', value: 'again', color: '#c0392b' },
-  { label: 'Hard', value: 'hard', color: '#e67e22' },
-  { label: 'Good', value: 'good', color: '#27ae60' },
-  { label: 'Easy', value: 'easy', color: '#2980b9' },
+const RATINGS: { label: string; value: Rating; color: string; key: string }[] = [
+  { label: 'Again', value: 'again', color: '#c0392b', key: '1' },
+  { label: 'Hard', value: 'hard', color: '#e67e22', key: '2' },
+  { label: 'Good', value: 'good', color: '#27ae60', key: '3' },
+  { label: 'Easy', value: 'easy', color: '#2980b9', key: '4' },
 ]
 
 interface Props {
@@ -16,6 +17,35 @@ interface Props {
 export const ReviewSession = ({ deckId }: Props = {}) => {
   const { currentCard, remaining, isRevealed, reveal, rate } = useReview(deckId)
   const reviewedToday = useReviewedToday()
+
+  // Use refs so the stable event listener always has the latest values
+  const isRevealedRef = useRef(isRevealed)
+  const revealRef = useRef(reveal)
+  const rateRef = useRef(rate)
+  const hasCardRef = useRef(!!currentCard)
+  isRevealedRef.current = isRevealed
+  revealRef.current = reveal
+  rateRef.current = rate
+  hasCardRef.current = !!currentCard
+
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (!hasCardRef.current) return
+      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return
+      if (!isRevealedRef.current && (e.code === 'Space' || e.key === ' ')) {
+        e.preventDefault()
+        revealRef.current()
+      } else if (isRevealedRef.current) {
+        const idx = ['1', '2', '3', '4'].indexOf(e.key)
+        if (idx !== -1) {
+          const rating = RATINGS[idx]
+          if (rating) void rateRef.current(rating.value)
+        }
+      }
+    }
+    window.addEventListener('keydown', handleKey)
+    return () => window.removeEventListener('keydown', handleKey)
+  }, []) // stable: runs once, reads live values through refs
 
   if (!currentCard) {
     return (

--- a/tests/e2e/flashcards.spec.ts
+++ b/tests/e2e/flashcards.spec.ts
@@ -55,6 +55,104 @@ test.describe('Flashcard app', () => {
     await page.getByRole('button', { name: 'Add' }).click()
     await page.getByRole('button', { name: 'Add Card' }).click()
     await expect(page.getByRole('alert')).toBeVisible()
+    // Also test front filled but back empty
+    await page.getByLabel('Front').fill('Some question')
+    await page.getByRole('button', { name: 'Add Card' }).click()
+    await expect(page.getByRole('alert')).toContainText('Back')
+  })
+
+  test('add card form shows success feedback after adding', async ({ page }) => {
+    await page.getByRole('button', { name: 'Add', exact: true }).click()
+    await page.getByLabel('Front').fill('What is 1 + 1?')
+    await page.getByLabel('Back').fill('2')
+    await page.getByRole('button', { name: 'Add Card' }).click()
+    await expect(page.getByRole('status')).toBeVisible()
+  })
+
+  test('empty deck name shows validation error', async ({ page }) => {
+    await page.getByRole('button', { name: 'Decks' }).click()
+    await page.getByRole('button', { name: 'Add Deck' }).click()
+    await expect(page.getByRole('alert')).toBeVisible()
+  })
+
+  test('Review button is disabled for empty decks', async ({ page }) => {
+    await page.getByRole('button', { name: 'Decks' }).click()
+    await page.getByLabel('Deck name').fill('Empty Deck')
+    await page.getByRole('button', { name: 'Add Deck' }).click()
+    const emptyDeckRow = page.locator('li').filter({ hasText: 'Empty Deck' })
+    const reviewBtn = emptyDeckRow.getByRole('button', { name: 'Review' })
+    await expect(reviewBtn).toBeDisabled()
+  })
+
+  test('card count updates after add and delete', async ({ page }) => {
+    await page.getByRole('button', { name: 'Cards' }).click()
+    const heading = page.getByRole('heading', { name: /All Cards/ })
+    const initialText = await heading.textContent()
+    const initialCount = parseInt(initialText?.match(/\d+/)?.[0] ?? '0')
+
+    // Add a card
+    await page.getByRole('button', { name: 'Add', exact: true }).click()
+    await page.getByLabel('Front').fill('Test front')
+    await page.getByLabel('Back').fill('Test back')
+    await page.getByRole('button', { name: 'Add Card' }).click()
+
+    await page.getByRole('button', { name: 'Cards' }).click()
+    await expect(heading).toContainText(String(initialCount + 1))
+
+    // Delete the card
+    await page.getByRole('button', { name: 'Delete card: Test front' }).click()
+    await expect(heading).toContainText(String(initialCount))
+  })
+
+  test('keyboard shortcut Space reveals answer', async ({ page }) => {
+    // Create an isolated deck for this test
+    await page.getByRole('button', { name: 'Decks' }).click()
+    await page.getByLabel('Deck name').fill('KB Test')
+    await page.getByRole('button', { name: 'Add Deck' }).click()
+
+    await page.getByRole('button', { name: 'Add', exact: true }).click()
+    await page.getByLabel('Deck').selectOption({ label: 'KB Test' })
+    await page.getByLabel('Front').fill('Press space')
+    await page.getByLabel('Back').fill('Done')
+    await page.getByRole('button', { name: 'Add Card' }).click()
+
+    await page.getByRole('button', { name: 'Decks' }).click()
+    await page.locator('li').filter({ hasText: 'KB Test' }).getByRole('button', { name: 'Review' }).click()
+    await expect(page.getByText('Press space')).toBeVisible()
+
+    await page.keyboard.press('Space')
+    await expect(page.getByText('Done')).toBeVisible()
+  })
+
+  test('keyboard shortcuts 1-4 rate cards', async ({ page }) => {
+    await page.getByRole('button', { name: 'Decks' }).click()
+    await page.getByLabel('Deck name').fill('KB Rate')
+    await page.getByRole('button', { name: 'Add Deck' }).click()
+
+    await page.getByRole('button', { name: 'Add', exact: true }).click()
+    await page.getByLabel('Deck').selectOption({ label: 'KB Rate' })
+    await page.getByLabel('Front').fill('Rate me')
+    await page.getByLabel('Back').fill('Answer')
+    await page.getByRole('button', { name: 'Add Card' }).click()
+
+    await page.getByRole('button', { name: 'Decks' }).click()
+    await page.locator('li').filter({ hasText: 'KB Rate' }).getByRole('button', { name: 'Review' }).click()
+    // Wait for the card to appear, then press Space to reveal
+    await expect(page.getByText('Rate me')).toBeVisible()
+    await page.keyboard.press('Space')
+    // Rating buttons appear after reveal (more specific than checking 'Answer' text which matches 'Show Answer' too)
+    await expect(page.getByRole('button', { name: 'Good' })).toBeVisible()
+
+    await page.keyboard.press('3')
+    await expect(page.getByText('All done!')).toBeVisible()
+  })
+
+  test('mobile nav shows all tabs at 390px width', async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 })
+    const tabs = ['Review', 'Decks', 'Cards', 'Add']
+    for (const tab of tabs) {
+      await expect(page.getByRole('button', { name: tab })).toBeVisible()
+    }
   })
 
   test('delete a card then undo restores it', async ({ page }) => {


### PR DESCRIPTION
## Summary
- Space reveals answer in review mode; keys 1–4 rate Again/Hard/Good/Easy
- Keyboard handler uses refs (runs once, reads live state) — avoids re-registration on every render
- AddCardForm shows a 3-second "Card added!" confirmation after successful submit
- 7 new E2E tests: keyboard shortcuts, success toast, empty deck name validation, review button disabled for empty decks, card count reactivity, mobile nav visibility
- Fixed a false-passing test: `getByText('Answer')` was matching the "Show Answer" button via partial text match

## Test plan
- [x] 15 E2E tests pass (`npx playwright test`)
- [x] 17 unit tests pass (`npx vitest run tests/unit`)
- [x] Type-check clean (`npx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)