### PR TITLE
docs: promote MEMORY lessons to CLAUDE.md + routine review in implement-issue

### DIFF
--- a/.claude/skills/implement-issue/SKILL.md
+++ b/.claude/skills/implement-issue/SKILL.md
@@ -5,8 +5,10 @@ description: >
   project. Use this whenever the user says "implement issue #N", "work on issue", "add feature X",
   "fix bug Y", or describes any change to make to the codebase. Follows strict TDD: failing tests
   first, then implementation, then full verification before committing and creating a PR.
+  After each session, promotes stable lessons from MEMORY.md into CLAUDE.md so project knowledge
+  accumulates in the canonical docs rather than only in personal memory.
   Always use this skill rather than ad-hoc implementation — it ensures the TDD workflow,
-  correct layering, and automated verification are never skipped.
+  correct layering, automated verification, and living documentation are never skipped.
 ---
 
 # Implement Issue
@@ -112,7 +114,10 @@ EOF
 2. Reflect on this implementation: errors hit and how they were fixed, architectural decisions, patterns discovered, pitfalls avoided
 3. Edit MEMORY.md — add only new, stable lessons not already captured. No duplicates. Keep it concise.
 4. **Save lessons immediately** — if you identify a lesson during implementation (e.g. "the fix for the future is…"), write it to MEMORY.md and this SKILL.md in the same response. Stating a lesson without saving it means it will be forgotten.
-5. Ask: **what additional steps could make this workflow more automated or effective?** If you have concrete ideas not already in MEMORY.md, add a brief "Workflow improvement ideas" section.
+5. **Promote stable lessons to CLAUDE.md** — after updating MEMORY.md, scan all lessons and ask: is this a stable technical fact about the codebase (not workflow meta) that isn't already in CLAUDE.md? If yes, add it. The distinction:
+   - **Promote to CLAUDE.md**: domain invariants, DB/API quirks, test patterns, coding constraints
+   - **Keep in MEMORY.md only**: git workflow rules, session-management meta, Claude-specific operating procedures
+6. Ask: **what additional steps could make this workflow more automated or effective?** If you have concrete ideas not already in MEMORY.md, add a brief "Workflow improvement ideas" section.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,17 +100,24 @@ Rating enum: `Again=1, Hard=2, Good=3, Easy=4` (Manual=0 unused).
 - Domain functions return new objects — never mutate.
 - `useLiveQuery` returns `undefined` on first render; always provide a default (`?? []` or `?? 0`).
 - `upsertSchedule` uses `db.schedules.put()` — idempotent.
-- Deleting a card also deletes its schedule in a single Dexie transaction. Deleting a deck deletes all its cards and schedules too.
+- Deleting a card also deletes its schedule in a single Dexie transaction. Deleting a deck deletes all its cards and schedules too (schedules → cards → deck, inside one `db.transaction('rw', ...)`).
 - `useReview(deckId?)` accepts an optional `deckId` — when provided it calls `getDueCardsByDeck`, otherwise `getDueCards`.
 - `noUncheckedIndexedAccess` is enabled — array/index access returns `T | undefined`; always null-check.
+- Cards with no schedule entry are treated as immediately due. `getDueCards`/`getDueCardsByDeck` use `bulkGet` on all card IDs and include any card whose schedule is missing or whose `due` timestamp is ≤ now.
+- React StrictMode (active in dev) runs effects twice. Any `useEffect` with side effects must be truly idempotent — guard with a check-then-write inside a single Dexie transaction, not a count check before it. See `ensureDefaultDeck()` for the canonical pattern.
+- When a `useEffect` event listener needs live state but should only register once, store the live values in refs and read them inside the stable handler. See `ReviewSession.tsx` keyboard shortcut handler for the canonical pattern.
 
 ## Tests
 
 Unit tests cover `src/domain/` only (pure functions). E2E tests cover full user flows in Chromium.
 
-E2E tests clear IndexedDB before each test via `indexedDB.databases()` + `deleteDatabase`, then `page.reload()`. After reload, always `waitForTimeout(200)` before asserting — `ensureDefaultDeck()` runs asynchronously on mount and the deck must exist before any card operation. The Playwright `webServer` config auto-starts the dev server if not already running.
+E2E tests clear IndexedDB before each test via `indexedDB.databases()` + `deleteDatabase`, then `page.reload()`. After reload, always `waitForTimeout(1000)` before asserting — `ensureDefaultDeck()` runs asynchronously on mount and the 1000-card seed `bulkAdd` takes longer than a simple insert. The Playwright `webServer` config auto-starts the dev server if not already running.
+
+The runtime IndexedDB database name is `'SpacedLearning'` (set in the Dexie constructor in `db.ts`). Use this when manually clearing storage: `indexedDB.deleteDatabase('SpacedLearning')`.
 
 When matching buttons by name, use `exact: true` if the label is a substring of another button's label (e.g. `getByRole('button', { name: 'Add', exact: true })` to avoid matching "Add Deck" too).
+
+Avoid `page.getByText('partial')` when that string appears as a substring of other visible text — e.g. `getByText('Answer')` matches the "Show Answer" button. Prefer `getByRole` with an exact name, or assert on a more specific element.
 
 `App.tsx` navigation uses a `View` union type — no router:
 


### PR DESCRIPTION
## Summary
- **CLAUDE.md fixes and additions** (7 changes):
  - Fix stale `waitForTimeout(200)` → `1000ms` (seed bulkAdd requires more time)
  - Add: IndexedDB runtime name is `'SpacedLearning'` (needed for `deleteDatabase`)
  - Add: `getByText` partial-match pitfall — prefer `getByRole` with exact name
  - Add: deck cascade-delete order (schedules → cards → deck in one transaction)
  - Add: unscheduled cards are immediately due (key domain invariant)
  - Add: React StrictMode double-invoke guard (check-then-write in Dexie transaction)
  - Add: stable refs pattern for event listeners that need live state (ReviewSession)
- **implement-issue SKILL.md**: step 9 now includes a "promote stable lessons to CLAUDE.md" sub-step after every session, with explicit criteria (technical facts → CLAUDE.md, workflow meta → MEMORY.md only). Description updated to reflect this responsibility.

## Why
MEMORY.md accumulates lessons each session but CLAUDE.md is the canonical always-loaded reference. Without a routine promotion step, stable technical knowledge stays locked in personal memory and must be rediscovered each time. This change closes that loop.

## Test plan
- [x] Unit tests pass
- [x] Type-check clean
- [x] Doc-only change — no runtime behaviour altered

🤖 Generated with [Claude Code](https://claude.com/claude-code)