### PR TITLE
feat: deck-centric navigation — 2 tabs, cards managed per-deck

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,21 +1,19 @@
 import { useState, useEffect } from 'react'
 import { ReviewSession } from './components/ReviewSession'
-import { CardList } from './components/CardList'
-import { AddCardForm } from './components/AddCardForm'
 import { DeckList } from './components/DeckList'
+import { DeckDetail } from './components/DeckDetail'
 import { ensureDefaultDeck } from './db/deckRepo'
 
-type Tab = 'review' | 'decks' | 'cards' | 'add'
+type Tab = 'review' | 'decks'
 
 type View =
   | { type: 'tab'; tab: Tab }
   | { type: 'deck-review'; deckId: string; deckName: string }
+  | { type: 'deck-detail'; deckId: string; deckName: string }
 
 const TABS: { id: Tab; label: string }[] = [
   { id: 'review', label: 'Review' },
   { id: 'decks', label: 'Decks' },
-  { id: 'cards', label: 'Cards' },
-  { id: 'add', label: 'Add' },
 ]
 
 export default function App() {
@@ -26,25 +24,27 @@ export default function App() {
   }, [])
 
   const activeTab = view.type === 'tab' ? view.tab : null
+  const isSubView = view.type === 'deck-review' || view.type === 'deck-detail'
+  const subViewName = isSubView ? view.deckName : ''
 
   return (
     <div style={{ maxWidth: '600px', margin: '0 auto', padding: '16px', fontFamily: 'sans-serif' }}>
       <header style={{ marginBottom: '24px', display: 'flex', alignItems: 'center', gap: '12px' }}>
-        {view.type === 'deck-review' && (
+        {isSubView && (
           <button
             onClick={() => setView({ type: 'tab', tab: 'decks' })}
+            aria-label="← Decks"
             style={{ background: 'none', border: 'none', color: '#aaa', cursor: 'pointer', fontSize: '1.2rem', padding: 0 }}
-            aria-label="Back to decks"
           >
             ←
           </button>
         )}
         <h1 style={{ margin: 0, fontSize: '1.5rem' }}>
-          {view.type === 'deck-review' ? view.deckName : 'Spaced Learning'}
+          {isSubView ? subViewName : 'Spaced Learning'}
         </h1>
       </header>
 
-      {view.type === 'tab' && (
+      {!isSubView && (
         <nav style={{ display: 'flex', gap: '8px', marginBottom: '24px' }}>
           {TABS.map(({ id, label }) => (
             <button
@@ -70,12 +70,14 @@ export default function App() {
 
       <main>
         {view.type === 'deck-review' && <ReviewSession deckId={view.deckId} />}
+        {view.type === 'deck-detail' && <DeckDetail deckId={view.deckId} deckName={view.deckName} />}
         {view.type === 'tab' && activeTab === 'review' && <ReviewSession />}
         {view.type === 'tab' && activeTab === 'decks' && (
-          <DeckList onReviewDeck={(deckId, deckName) => setView({ type: 'deck-review', deckId, deckName })} />
+          <DeckList
+            onOpenDeck={(deckId, deckName) => setView({ type: 'deck-detail', deckId, deckName })}
+            onReviewDeck={(deckId, deckName) => setView({ type: 'deck-review', deckId, deckName })}
+          />
         )}
-        {view.type === 'tab' && activeTab === 'cards' && <CardList />}
-        {view.type === 'tab' && activeTab === 'add' && <AddCardForm />}
       </main>
     </div>
   )

--- a/src/components/AddCardForm.tsx
+++ b/src/components/AddCardForm.tsx
@@ -3,13 +3,14 @@ import { createCard } from '../domain/cards'
 import { addCard } from '../db/cardRepo'
 import { upsertSchedule } from '../db/reviewRepo'
 import { createNewSchedule } from '../domain/scheduler'
-import { useDecks } from '../hooks/useDecks'
 
-export const AddCardForm = () => {
-  const decks = useDecks()
+interface Props {
+  readonly deckId: string
+}
+
+export const AddCardForm = ({ deckId }: Props) => {
   const [front, setFront] = useState('')
   const [back, setBack] = useState('')
-  const [deckId, setDeckId] = useState('')
   const [error, setError] = useState('')
   const [success, setSuccess] = useState(false)
   const successTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -20,18 +21,11 @@ export const AddCardForm = () => {
     }
   }, [])
 
-  // Default to the first deck when decks load
-  const selectedDeckId = deckId || decks[0]?.id || ''
-
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault()
     setError('')
-    if (!selectedDeckId) {
-      setError('Create a deck first in the Decks tab')
-      return
-    }
     try {
-      const card = createCard(front, back, selectedDeckId)
+      const card = createCard(front, back, deckId)
       await addCard(card)
       await upsertSchedule(card.id, createNewSchedule())
       setFront('')
@@ -46,25 +40,9 @@ export const AddCardForm = () => {
 
   return (
     <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
-      <h2>Add Card</h2>
-      {error && <p style={{ color: 'red' }} role="alert">{error}</p>}
-      {success && <p style={{ color: '#27ae60' }} role="status">Card added!</p>}
-      <label>
-        Deck
-        <select
-          value={selectedDeckId}
-          onChange={(e) => setDeckId(e.target.value)}
-          style={{ display: 'block', width: '100%', marginTop: '4px', padding: '8px', background: '#1e1e2e', border: '1px solid #444', borderRadius: '4px', color: '#e0e0e0' }}
-        >
-          {decks.length === 0 ? (
-            <option value="">No decks — create one first</option>
-          ) : (
-            decks.map((d) => (
-              <option key={d.id} value={d.id}>{d.name}</option>
-            ))
-          )}
-        </select>
-      </label>
+      <h3 style={{ margin: 0 }}>Add Card</h3>
+      {error && <p style={{ color: 'red', margin: 0 }} role="alert">{error}</p>}
+      {success && <p style={{ color: '#27ae60', margin: 0 }} role="status">Card added!</p>}
       <label>
         Front
         <textarea

--- a/src/components/CardList.tsx
+++ b/src/components/CardList.tsx
@@ -10,8 +10,13 @@ interface UndoState {
   timeoutId: ReturnType<typeof setTimeout>
 }
 
-export const CardList = () => {
-  const cards = useCards()
+interface Props {
+  readonly deckId: string
+  readonly deckName: string
+}
+
+export const CardList = ({ deckId, deckName }: Props) => {
+  const cards = useCards(deckId)
   const [undo, setUndo] = useState<UndoState | null>(null)
 
   useEffect(() => {
@@ -38,13 +43,10 @@ export const CardList = () => {
     setUndo(null)
   }
 
-  if (cards.length === 0 && !undo) {
-    return <p>No cards yet. Add some!</p>
-  }
-
   return (
     <div>
-      <h2>All Cards ({cards.length})</h2>
+      <h2>{deckName} — Cards ({cards.length})</h2>
+      {cards.length === 0 && !undo && <p style={{ color: '#888' }}>No cards yet. Add one above.</p>}
       <ul style={{ listStyle: 'none', padding: 0 }}>
         {cards.map((card) => (
           <li

--- a/src/components/DeckDetail.tsx
+++ b/src/components/DeckDetail.tsx
@@ -1,0 +1,15 @@
+import { AddCardForm } from './AddCardForm'
+import { CardList } from './CardList'
+
+interface Props {
+  readonly deckId: string
+  readonly deckName: string
+}
+
+export const DeckDetail = ({ deckId, deckName }: Props) => (
+  <div style={{ display: 'flex', flexDirection: 'column', gap: '24px' }}>
+    <AddCardForm deckId={deckId} />
+    <hr style={{ border: 'none', borderTop: '1px solid #333', margin: 0 }} />
+    <CardList deckId={deckId} deckName={deckName} />
+  </div>
+)

--- a/src/components/DeckList.tsx
+++ b/src/components/DeckList.tsx
@@ -6,6 +6,7 @@ import type { Card, Deck } from '../domain/types'
 import type { ScheduleRecord } from '../db/db'
 
 interface Props {
+  readonly onOpenDeck: (deckId: string, deckName: string) => void
   readonly onReviewDeck: (deckId: string, deckName: string) => void
 }
 
@@ -16,7 +17,7 @@ interface UndoState {
   timeoutId: ReturnType<typeof setTimeout>
 }
 
-export const DeckList = ({ onReviewDeck }: Props) => {
+export const DeckList = ({ onOpenDeck, onReviewDeck }: Props) => {
   const deckStats = useDeckStats()
   const [newName, setNewName] = useState('')
   const [error, setError] = useState('')
@@ -110,6 +111,12 @@ export const DeckList = ({ onReviewDeck }: Props) => {
                   )}
                 </div>
               </div>
+              <button
+                onClick={() => onOpenDeck(deck.id, deck.name)}
+                style={{ padding: '6px 14px', background: '#2980b9', border: 'none', borderRadius: '4px', color: '#fff', cursor: 'pointer' }}
+              >
+                Cards
+              </button>
               <button
                 onClick={() => onReviewDeck(deck.id, deck.name)}
                 disabled={dueCount === 0}

--- a/src/hooks/useCards.ts
+++ b/src/hooks/useCards.ts
@@ -2,5 +2,12 @@ import { useLiveQuery } from 'dexie-react-hooks'
 import { db } from '../db/db'
 import type { Card } from '../domain/types'
 
-export const useCards = (): Card[] =>
-  useLiveQuery(() => db.cards.orderBy('createdAt').toArray(), [], []) ?? []
+export const useCards = (deckId?: string): Card[] =>
+  useLiveQuery(
+    () =>
+      deckId
+        ? db.cards.where('deckId').equals(deckId).sortBy('createdAt')
+        : db.cards.orderBy('createdAt').toArray(),
+    [deckId],
+    [],
+  ) ?? []

--- a/tests/e2e/flashcards.spec.ts
+++ b/tests/e2e/flashcards.spec.ts
@@ -15,44 +15,63 @@ test.describe('Flashcard app', () => {
     await page.waitForTimeout(1000)
   })
 
-  test('add a card and see it in the card list', async ({ page }) => {
-    await page.getByRole('button', { name: 'Add' }).click()
+  // ── Navigation ──────────────────────────────────────────────────────────────
 
-    // Default deck is pre-selected; just fill front and back
+  test('only Review and Decks tabs are visible', async ({ page }) => {
+    await expect(page.getByRole('button', { name: 'Review' })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Decks' })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Cards' })).not.toBeVisible()
+    await expect(page.getByRole('button', { name: 'Add' })).not.toBeVisible()
+  })
+
+  test('mobile nav shows both tabs at 390px width', async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 })
+    await expect(page.getByRole('button', { name: 'Review' })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Decks' })).toBeVisible()
+  })
+
+  // ── Deck detail: add & view cards ───────────────────────────────────────────
+
+  test('opening a deck shows its cards and an add form', async ({ page }) => {
+    await page.getByRole('button', { name: 'Decks' }).click()
+    const seedRow = page.locator('li').filter({ hasText: '1000 most common words in Vietnamese' }).first()
+    await seedRow.getByRole('button', { name: 'Cards' }).click()
+
+    // Should show AddCardForm (no deck selector — deckId is injected)
+    await expect(page.getByLabel('Front')).toBeVisible()
+    await expect(page.getByLabel('Back')).toBeVisible()
+    // Should NOT show a deck <select>
+    await expect(page.getByRole('combobox')).not.toBeVisible()
+  })
+
+  test('add a card from within a deck and see it in the card list', async ({ page }) => {
+    await page.getByRole('button', { name: 'Decks' }).click()
+    await page.getByLabel('Deck name').fill('French')
+    await page.getByRole('button', { name: 'Add Deck' }).click()
+
+    await page.locator('li').filter({ hasText: 'French' }).getByRole('button', { name: 'Cards' }).click()
     await page.getByLabel('Front').fill('What is the capital of France?')
     await page.getByLabel('Back').fill('Paris')
     await page.getByRole('button', { name: 'Add Card' }).click()
 
-    await page.getByRole('button', { name: 'Cards' }).click()
     await expect(page.getByText('What is the capital of France?')).toBeVisible()
     await expect(page.getByText('Paris')).toBeVisible()
   })
 
-  test('review a card with Good rating removes it from the due queue temporarily', async ({ page }) => {
-    // Create a dedicated deck so we can review it in isolation
+  test('add card form shows success feedback after adding', async ({ page }) => {
     await page.getByRole('button', { name: 'Decks' }).click()
-    await page.getByLabel('Deck name').fill('Math')
-    await page.getByRole('button', { name: 'Add Deck' }).click()
-
-    await page.getByRole('button', { name: 'Add', exact: true }).click()
-    await page.getByLabel('Deck').selectOption({ label: 'Math' })
-    await page.getByLabel('Front').fill('What is 2 + 2?')
-    await page.getByLabel('Back').fill('4')
+    const seedRow = page.locator('li').filter({ hasText: '1000 most common words in Vietnamese' }).first()
+    await seedRow.getByRole('button', { name: 'Cards' }).click()
+    await page.getByLabel('Front').fill('Test front')
+    await page.getByLabel('Back').fill('Test back')
     await page.getByRole('button', { name: 'Add Card' }).click()
-
-    await page.getByRole('button', { name: 'Decks' }).click()
-    await page.locator('li').filter({ hasText: 'Math' }).getByRole('button', { name: 'Review' }).click()
-    await expect(page.getByText('What is 2 + 2?')).toBeVisible()
-
-    await page.getByRole('button', { name: 'Show Answer' }).click()
-    await expect(page.getByText('4')).toBeVisible()
-    await page.getByRole('button', { name: 'Good' }).click()
-
-    await expect(page.getByText('All done!')).toBeVisible()
+    await expect(page.getByRole('status')).toBeVisible()
   })
 
   test('add card form shows error for empty fields', async ({ page }) => {
-    await page.getByRole('button', { name: 'Add' }).click()
+    await page.getByRole('button', { name: 'Decks' }).click()
+    const seedRow = page.locator('li').filter({ hasText: '1000 most common words in Vietnamese' }).first()
+    await seedRow.getByRole('button', { name: 'Cards' }).click()
     await page.getByRole('button', { name: 'Add Card' }).click()
     await expect(page.getByRole('alert')).toBeVisible()
     // Also test front filled but back empty
@@ -61,13 +80,43 @@ test.describe('Flashcard app', () => {
     await expect(page.getByRole('alert')).toContainText('Back')
   })
 
-  test('add card form shows success feedback after adding', async ({ page }) => {
-    await page.getByRole('button', { name: 'Add', exact: true }).click()
-    await page.getByLabel('Front').fill('What is 1 + 1?')
-    await page.getByLabel('Back').fill('2')
+  test('card count updates after add and delete', async ({ page }) => {
+    await page.getByRole('button', { name: 'Decks' }).click()
+    await page.getByLabel('Deck name').fill('Count Test')
+    await page.getByRole('button', { name: 'Add Deck' }).click()
+    await page.locator('li').filter({ hasText: 'Count Test' }).getByRole('button', { name: 'Cards' }).click()
+
+    const heading = page.getByRole('heading', { name: /Cards/ })
+    await expect(heading).toContainText('0')
+
+    await page.getByLabel('Front').fill('Test front')
+    await page.getByLabel('Back').fill('Test back')
     await page.getByRole('button', { name: 'Add Card' }).click()
-    await expect(page.getByRole('status')).toBeVisible()
+    await expect(heading).toContainText('1')
+
+    await page.getByRole('button', { name: 'Delete card: Test front' }).click()
+    await expect(heading).toContainText('0')
   })
+
+  test('delete a card then undo restores it', async ({ page }) => {
+    await page.getByRole('button', { name: 'Decks' }).click()
+    await page.getByLabel('Deck name').fill('Undo Test')
+    await page.getByRole('button', { name: 'Add Deck' }).click()
+    await page.locator('li').filter({ hasText: 'Undo Test' }).getByRole('button', { name: 'Cards' }).click()
+
+    await page.getByLabel('Front').fill('Capital of Japan')
+    await page.getByLabel('Back').fill('Tokyo')
+    await page.getByRole('button', { name: 'Add Card' }).click()
+    await expect(page.getByText('Capital of Japan')).toBeVisible()
+
+    await page.getByRole('button', { name: 'Delete card: Capital of Japan' }).click()
+    await expect(page.getByText('Capital of Japan')).not.toBeVisible()
+
+    await page.getByRole('button', { name: 'Undo' }).click()
+    await expect(page.getByText('Capital of Japan')).toBeVisible()
+  })
+
+  // ── Deck management ─────────────────────────────────────────────────────────
 
   test('empty deck name shows validation error', async ({ page }) => {
     await page.getByRole('button', { name: 'Decks' }).click()
@@ -80,95 +129,7 @@ test.describe('Flashcard app', () => {
     await page.getByLabel('Deck name').fill('Empty Deck')
     await page.getByRole('button', { name: 'Add Deck' }).click()
     const emptyDeckRow = page.locator('li').filter({ hasText: 'Empty Deck' })
-    const reviewBtn = emptyDeckRow.getByRole('button', { name: 'Review' })
-    await expect(reviewBtn).toBeDisabled()
-  })
-
-  test('card count updates after add and delete', async ({ page }) => {
-    await page.getByRole('button', { name: 'Cards' }).click()
-    const heading = page.getByRole('heading', { name: /All Cards/ })
-    const initialText = await heading.textContent()
-    const initialCount = parseInt(initialText?.match(/\d+/)?.[0] ?? '0')
-
-    // Add a card
-    await page.getByRole('button', { name: 'Add', exact: true }).click()
-    await page.getByLabel('Front').fill('Test front')
-    await page.getByLabel('Back').fill('Test back')
-    await page.getByRole('button', { name: 'Add Card' }).click()
-
-    await page.getByRole('button', { name: 'Cards' }).click()
-    await expect(heading).toContainText(String(initialCount + 1))
-
-    // Delete the card
-    await page.getByRole('button', { name: 'Delete card: Test front' }).click()
-    await expect(heading).toContainText(String(initialCount))
-  })
-
-  test('keyboard shortcut Space reveals answer', async ({ page }) => {
-    // Create an isolated deck for this test
-    await page.getByRole('button', { name: 'Decks' }).click()
-    await page.getByLabel('Deck name').fill('KB Test')
-    await page.getByRole('button', { name: 'Add Deck' }).click()
-
-    await page.getByRole('button', { name: 'Add', exact: true }).click()
-    await page.getByLabel('Deck').selectOption({ label: 'KB Test' })
-    await page.getByLabel('Front').fill('Press space')
-    await page.getByLabel('Back').fill('Done')
-    await page.getByRole('button', { name: 'Add Card' }).click()
-
-    await page.getByRole('button', { name: 'Decks' }).click()
-    await page.locator('li').filter({ hasText: 'KB Test' }).getByRole('button', { name: 'Review' }).click()
-    await expect(page.getByText('Press space')).toBeVisible()
-
-    await page.keyboard.press('Space')
-    await expect(page.getByText('Done')).toBeVisible()
-  })
-
-  test('keyboard shortcuts 1-4 rate cards', async ({ page }) => {
-    await page.getByRole('button', { name: 'Decks' }).click()
-    await page.getByLabel('Deck name').fill('KB Rate')
-    await page.getByRole('button', { name: 'Add Deck' }).click()
-
-    await page.getByRole('button', { name: 'Add', exact: true }).click()
-    await page.getByLabel('Deck').selectOption({ label: 'KB Rate' })
-    await page.getByLabel('Front').fill('Rate me')
-    await page.getByLabel('Back').fill('Answer')
-    await page.getByRole('button', { name: 'Add Card' }).click()
-
-    await page.getByRole('button', { name: 'Decks' }).click()
-    await page.locator('li').filter({ hasText: 'KB Rate' }).getByRole('button', { name: 'Review' }).click()
-    // Wait for the card to appear, then press Space to reveal
-    await expect(page.getByText('Rate me')).toBeVisible()
-    await page.keyboard.press('Space')
-    // Rating buttons appear after reveal (more specific than checking 'Answer' text which matches 'Show Answer' too)
-    await expect(page.getByRole('button', { name: 'Good' })).toBeVisible()
-
-    await page.keyboard.press('3')
-    await expect(page.getByText('All done!')).toBeVisible()
-  })
-
-  test('mobile nav shows all tabs at 390px width', async ({ page }) => {
-    await page.setViewportSize({ width: 390, height: 844 })
-    const tabs = ['Review', 'Decks', 'Cards', 'Add']
-    for (const tab of tabs) {
-      await expect(page.getByRole('button', { name: tab })).toBeVisible()
-    }
-  })
-
-  test('delete a card then undo restores it', async ({ page }) => {
-    await page.getByRole('button', { name: 'Add', exact: true }).click()
-    await page.getByLabel('Front').fill('Capital of Japan')
-    await page.getByLabel('Back').fill('Tokyo')
-    await page.getByRole('button', { name: 'Add Card' }).click()
-
-    await page.getByRole('button', { name: 'Cards' }).click()
-    await expect(page.getByText('Capital of Japan')).toBeVisible()
-
-    await page.getByRole('button', { name: 'Delete card: Capital of Japan' }).click()
-    await expect(page.getByText('Capital of Japan')).not.toBeVisible()
-
-    await page.getByRole('button', { name: 'Undo' }).click()
-    await expect(page.getByText('Capital of Japan')).toBeVisible()
+    await expect(emptyDeckRow.getByRole('button', { name: 'Review' })).toBeDisabled()
   })
 
   test('delete a deck requires confirmation and cancel keeps it', async ({ page }) => {
@@ -183,61 +144,112 @@ test.describe('Flashcard app', () => {
     await expect(page.getByText('History')).toBeVisible()
   })
 
-  test('delete a deck then undo restores it', async ({ page }) => {
+  test('delete a deck then undo restores it with its cards', async ({ page }) => {
     await page.getByRole('button', { name: 'Decks' }).click()
     await page.getByLabel('Deck name').fill('Geography')
     await page.getByRole('button', { name: 'Add Deck' }).click()
 
-    // Add a card to the deck
-    await page.getByRole('button', { name: 'Add', exact: true }).click()
-    await page.getByLabel('Deck').selectOption({ label: 'Geography' })
+    await page.locator('li').filter({ hasText: 'Geography' }).getByRole('button', { name: 'Cards' }).click()
     await page.getByLabel('Front').fill('Largest country by area')
     await page.getByLabel('Back').fill('Russia')
     await page.getByRole('button', { name: 'Add Card' }).click()
 
-    // Delete the deck (confirm)
-    await page.getByRole('button', { name: 'Decks' }).click()
+    await page.getByRole('button', { name: '← Decks' }).click()
     await page.locator('li').filter({ hasText: 'Geography' }).getByRole('button', { name: /delete deck geography/i }).click()
     await page.getByRole('dialog').getByRole('button', { name: 'Delete' }).click()
     await expect(page.getByText('Geography')).not.toBeVisible()
 
-    // Undo — deck and card come back
     await page.getByRole('button', { name: 'Undo' }).click()
     await expect(page.getByText('Geography')).toBeVisible()
   })
 
+  // ── Review ───────────────────────────────────────────────────────────────────
+
   test('Review button is enabled for deck with unscheduled cards', async ({ page }) => {
-    // The seed deck has 1000 cards, none reviewed (no schedule entries)
-    // The Review button must be enabled because unscheduled cards are immediately due
     await page.getByRole('button', { name: 'Decks' }).click()
     const seedDeckRow = page.locator('li').filter({ hasText: '1000 most common words in Vietnamese' }).first()
     await expect(seedDeckRow).toBeVisible()
-    const reviewBtn = seedDeckRow.getByRole('button', { name: 'Review' })
-    await expect(reviewBtn).not.toBeDisabled()
+    await expect(seedDeckRow.getByRole('button', { name: 'Review' })).not.toBeDisabled()
+  })
+
+  test('review a card with Good rating removes it from the due queue', async ({ page }) => {
+    await page.getByRole('button', { name: 'Decks' }).click()
+    await page.getByLabel('Deck name').fill('Math')
+    await page.getByRole('button', { name: 'Add Deck' }).click()
+
+    await page.locator('li').filter({ hasText: 'Math' }).getByRole('button', { name: 'Cards' }).click()
+    await page.getByLabel('Front').fill('What is 2 + 2?')
+    await page.getByLabel('Back').fill('4')
+    await page.getByRole('button', { name: 'Add Card' }).click()
+
+    await page.getByRole('button', { name: '← Decks' }).click()
+    await page.locator('li').filter({ hasText: 'Math' }).getByRole('button', { name: 'Review' }).click()
+    await expect(page.getByText('What is 2 + 2?')).toBeVisible()
+    await page.getByRole('button', { name: 'Show Answer' }).click()
+    await page.getByRole('button', { name: 'Good' }).click()
+    await expect(page.getByText('All done!')).toBeVisible()
   })
 
   test('create a deck and review only its cards', async ({ page }) => {
-    // Create a second deck
     await page.getByRole('button', { name: 'Decks' }).click()
     await page.getByLabel('Deck name').fill('Spanish')
     await page.getByRole('button', { name: 'Add Deck' }).click()
-    await expect(page.getByText('Spanish')).toBeVisible()
 
-    // Add a card to the Spanish deck
-    await page.getByRole('button', { name: 'Add', exact: true }).click()
-    await page.getByLabel('Deck').selectOption({ label: 'Spanish' })
+    await page.locator('li').filter({ hasText: 'Spanish' }).getByRole('button', { name: 'Cards' }).click()
     await page.getByLabel('Front').fill('Hola')
     await page.getByLabel('Back').fill('Hello')
     await page.getByRole('button', { name: 'Add Card' }).click()
 
-    // Review the Spanish deck — should only show the Spanish card
-    await page.getByRole('button', { name: 'Decks' }).click()
+    await page.getByRole('button', { name: '← Decks' }).click()
     await page.locator('li').filter({ hasText: 'Spanish' }).getByRole('button', { name: 'Review' }).click()
     await expect(page.getByText('Hola')).toBeVisible()
-
-    // Rate Good and queue should be empty for this deck
     await page.getByRole('button', { name: 'Show Answer' }).click()
     await page.getByRole('button', { name: 'Good' }).click()
+    await expect(page.getByText('All done!')).toBeVisible()
+  })
+
+  test('global Review tab reviews all due cards', async ({ page }) => {
+    // Global review tab should still work (not deck-scoped)
+    await page.getByRole('button', { name: 'Review' }).click()
+    // Seed deck has 1000 unscheduled (due) cards
+    await expect(page.getByText(/cards remaining/)).toBeVisible()
+  })
+
+  // ── Keyboard shortcuts ───────────────────────────────────────────────────────
+
+  test('keyboard shortcut Space reveals answer', async ({ page }) => {
+    await page.getByRole('button', { name: 'Decks' }).click()
+    await page.getByLabel('Deck name').fill('KB Test')
+    await page.getByRole('button', { name: 'Add Deck' }).click()
+
+    await page.locator('li').filter({ hasText: 'KB Test' }).getByRole('button', { name: 'Cards' }).click()
+    await page.getByLabel('Front').fill('Press space')
+    await page.getByLabel('Back').fill('Done')
+    await page.getByRole('button', { name: 'Add Card' }).click()
+
+    await page.getByRole('button', { name: '← Decks' }).click()
+    await page.locator('li').filter({ hasText: 'KB Test' }).getByRole('button', { name: 'Review' }).click()
+    await expect(page.getByText('Press space')).toBeVisible()
+    await page.keyboard.press('Space')
+    await expect(page.getByText('Done')).toBeVisible()
+  })
+
+  test('keyboard shortcuts 1-4 rate cards', async ({ page }) => {
+    await page.getByRole('button', { name: 'Decks' }).click()
+    await page.getByLabel('Deck name').fill('KB Rate')
+    await page.getByRole('button', { name: 'Add Deck' }).click()
+
+    await page.locator('li').filter({ hasText: 'KB Rate' }).getByRole('button', { name: 'Cards' }).click()
+    await page.getByLabel('Front').fill('Rate me')
+    await page.getByLabel('Back').fill('Answer')
+    await page.getByRole('button', { name: 'Add Card' }).click()
+
+    await page.getByRole('button', { name: '← Decks' }).click()
+    await page.locator('li').filter({ hasText: 'KB Rate' }).getByRole('button', { name: 'Review' }).click()
+    await expect(page.getByText('Rate me')).toBeVisible()
+    await page.keyboard.press('Space')
+    await expect(page.getByRole('button', { name: 'Good' })).toBeVisible()
+    await page.keyboard.press('3')
     await expect(page.getByText('All done!')).toBeVisible()
   })
 })


### PR DESCRIPTION
## Summary
- Reduces main navigation from 4 tabs (Review/Decks/Cards/Add) to 2 (Review/Decks)
- Each deck row now has a **Cards** button that opens a deck-detail view showing the card list and an add-card form scoped to that deck — no deck selector needed
- `AddCardForm` receives `deckId` as a required prop (no `useDecks` hook, no `<select>`)
- `CardList` receives `deckId` + `deckName`; `useCards(deckId?)` filters via `where('deckId').equals()`
- New `DeckDetail` component composes `AddCardForm` + `CardList` for a deck
- Back button uses `aria-label="← Decks"` (not "← Back") to avoid Playwright's substring `getByLabel` matching the Back textarea

## Test plan
- [x] 18 E2E tests pass — full suite rewritten for new navigation flow
- [x] 17 unit tests pass
- [x] Type-check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)