### PR TITLE
feat: trigger implement-issue from GitHub Issues via self-hosted runner

### DIFF
--- a/.claude/skills/implement-issue/SKILL.md
+++ b/.claude/skills/implement-issue/SKILL.md
@@ -91,6 +91,9 @@ Before pushing, confirm the PR for this branch is still open (not already merged
 gh pr list --state all --head $(git branch --show-current)
 ```
 If status is MERGED, the branch is stale — create a new branch from main and start a new PR.
+
+When triggered from a GitHub Issue (i.e. an issue number was given in step 1), include `Closes #<N>` in the PR body so GitHub auto-closes the issue on merge.
+
 ```bash
 gh pr create --title "<concise title under 70 chars>" --body "$(cat <<'EOF'
 ## Summary
@@ -102,10 +105,14 @@ gh pr create --title "<concise title under 70 chars>" --body "$(cat <<'EOF'
 - [ ] E2E tests pass (`npx playwright test`)
 - [ ] Type-check clean (`npx tsc --noEmit`)
 
+Closes #<issue-number>
+
 🤖 Generated with [Claude Code](https://claude.com/claude-code)
 EOF
 )"
 ```
+
+Omit the `Closes #N` line when there is no associated issue.
 
 ### 9. Consolidate learnings
 `npm run memory:sync` cannot run inside an active Claude Code session (it uses `claude -p` which would nest sessions). Instead, update MEMORY.md directly:

--- a/.github/RUNNER_SETUP.md
+++ b/.github/RUNNER_SETUP.md
@@ -1,0 +1,71 @@
+# Self-hosted Runner Setup
+
+This project uses a self-hosted GitHub Actions runner on the local development machine to run `claude --dangerously-skip-permissions` in response to GitHub Issues labeled `auto-implement`.
+
+## Why self-hosted?
+
+The `claude` CLI must run locally: it reads/writes project files, runs the dev server, executes Playwright E2E tests against a real browser, and commits/pushes via the local git identity. None of this works in an ephemeral GitHub-hosted runner.
+
+## One-time setup
+
+### 1. Register the runner
+
+1. Go to **Settings → Actions → Runners → New self-hosted runner** in the GitHub repo
+2. Select Linux / x64
+3. Follow the download and configuration steps shown (creates a `actions-runner/` directory)
+4. When prompted for runner name/labels, the default is fine
+
+### 2. Install as a system service
+
+```bash
+cd ~/actions-runner
+sudo ./svc.sh install
+sudo ./svc.sh start
+```
+
+Verify it's running:
+```bash
+sudo ./svc.sh status
+```
+
+The runner will now start automatically on boot and process jobs in the background.
+
+### 3. Add `ANTHROPIC_API_KEY` secret
+
+Go to **Settings → Secrets and variables → Actions → New repository secret**:
+
+- Name: `ANTHROPIC_API_KEY`
+- Value: your Anthropic API key
+
+The workflow passes this to `claude` so it can call the model.
+
+### 4. Create the `auto-implement` label
+
+```bash
+gh label create auto-implement --color 0075ca --description "Trigger Claude Code to implement this issue automatically"
+```
+
+## Using it
+
+1. Create a GitHub Issue describing the feature or fix
+2. Add the `auto-implement` label to the issue
+3. The workflow triggers immediately; Claude Code will:
+   - Read the issue
+   - Create a branch from `main`
+   - Write failing tests
+   - Implement the feature
+   - Verify all tests pass
+   - Commit and open a PR that auto-closes the issue
+
+A comment is posted to the issue when Claude starts. If the run fails, a failure comment is posted with a link to the workflow logs.
+
+## Security note
+
+Any repository collaborator with permission to add labels can trigger an automated run. Restrict who can add labels via GitHub's repository role settings if needed. The runner process runs as your local user account, so it has full access to your machine.
+
+## Stopping the runner
+
+```bash
+cd ~/actions-runner
+sudo ./svc.sh stop
+```

--- a/.github/workflows/implement-from-issue.yml
+++ b/.github/workflows/implement-from-issue.yml
@@ -1,0 +1,54 @@
+name: Implement Issue via Claude Code CLI
+
+# Triggered when the 'auto-implement' label is added to an issue.
+# Runs claude --dangerously-skip-permissions on the self-hosted runner
+# (this machine), which executes the full implement-issue TDD workflow
+# locally and opens a PR that closes the issue.
+#
+# Setup: see .github/RUNNER_SETUP.md
+
+on:
+  issues:
+    types: [labeled]
+
+jobs:
+  implement:
+    name: implement-issue #${{ github.event.issue.number }}
+    if: github.event.label.name == 'auto-implement'
+    runs-on: self-hosted
+    timeout-minutes: 60
+
+    steps:
+      - name: Comment on issue (starting)
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: '🤖 **Claude Code** is starting work on this issue. A PR will be created when done.'
+            })
+
+      - name: Run implement-issue via Claude Code CLI
+        working-directory: /home/bahm/Projects/spaced-learning
+        run: |
+          export NVM_DIR="${HOME}/.nvm"
+          source "${NVM_DIR}/nvm.sh"
+          claude --dangerously-skip-permissions -p \
+            "implement issue #${{ github.event.issue.number }}"
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Comment on issue (failure)
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: '❌ **Claude Code** encountered an error while working on this issue. Check the [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details.'
+            })

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,7 @@ The core principle is **separation of pure logic from side effects**:
 - `src/db/` — Dexie/IndexedDB side effects. Never imported by `domain/`.
 - `src/hooks/` — React hooks for **reactive reads** via `useLiveQuery` from `dexie-react-hooks`.
 - `src/components/` — thin UI shells. No raw `db.*` calls; repo functions are fine.
-- `App.tsx` — tab switcher (Review / Decks / Cards / Add) + deck-review sub-view using a `View` union type. No router library.
+- `App.tsx` — tab switcher (Review / Decks) + deck-detail and deck-review sub-views using a `View` union type. No router library.
 
 **Read path**: hooks use `useLiveQuery` → Dexie re-fires on table mutation → component re-renders.
 **Write path**: components call repo functions directly (e.g. `addCard`, `upsertSchedule`, `deleteCard`) — no hook needed for writes.
@@ -119,12 +119,16 @@ When matching buttons by name, use `exact: true` if the label is a substring of 
 
 Avoid `page.getByText('partial')` when that string appears as a substring of other visible text — e.g. `getByText('Answer')` matches the "Show Answer" button. Prefer `getByRole` with an exact name, or assert on a more specific element.
 
+**`getByLabel` aria-label collision**: Playwright's `getByLabel` matches ANY element with a matching `aria-label` attribute (not just form controls) using substring matching. Nav buttons with `aria-label` values that are substrings of form field labels will collide. Design nav button `aria-label` values to avoid substrings of field labels (e.g. use `"← Decks"` not `"← Back"` when a "Back" textarea exists). Use `getByRole('combobox')` to target `<select>` elements specifically.
+
 `App.tsx` navigation uses a `View` union type — no router:
 
 ```typescript
+type Tab = 'review' | 'decks'
 type View =
-  | { type: 'tab'; tab: 'review' | 'decks' | 'cards' | 'add' }
+  | { type: 'tab'; tab: Tab }
   | { type: 'deck-review'; deckId: string; deckName: string }
+  | { type: 'deck-detail'; deckId: string; deckName: string }
 ```
 
-Tab nav is hidden in `deck-review` view; a back arrow navigates to the Decks tab.
+Tab nav (Review / Decks) is hidden in sub-views (`deck-review`, `deck-detail`); a back arrow (`aria-label="← Decks"`) navigates to the Decks tab. Cards are viewed and added from within a deck (`DeckDetail` component = `AddCardForm` + `CardList` scoped to a `deckId`). `AddCardForm` requires a `deckId` prop — no deck selector shown to the user.


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/implement-from-issue.yml`: triggers when an issue is labeled `auto-implement`, posts a start comment, then runs `claude --dangerously-skip-permissions -p "implement issue #N"` on the self-hosted runner (this local machine)
- Updates `implement-issue` skill step 8 to include `Closes #N` in PR bodies so merging auto-closes the originating issue
- Adds `.github/RUNNER_SETUP.md` with step-by-step instructions to register and daemonize the self-hosted runner
- Creates `auto-implement` label on the repo

## How it works
1. Create a GitHub Issue describing the feature or fix
2. Add the `auto-implement` label
3. The workflow triggers; Claude Code CLI runs the full TDD implement-issue workflow locally and opens a PR

**Note**: requires a self-hosted runner registered on this machine — see `.github/RUNNER_SETUP.md`.

## Test plan
- [ ] Unit tests pass (`npx vitest run tests/unit`)
- [ ] E2E tests pass (`npx playwright test`)
- [ ] Type-check clean (`npx tsc --noEmit`)
- [ ] Manual: label a test issue and verify Claude Code triggers and creates a PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)