### PR TITLE
fix: add working-directory to Verify PR step

### DIFF
--- a/.github/workflows/implement-from-issue.yml
+++ b/.github/workflows/implement-from-issue.yml
@@ -60,11 +60,12 @@ jobs:
           GH_TOKEN: ${{ github.token }}
 
       - name: Verify PR was created
+        working-directory: /home/bahm/Projects/spaced-learning
         run: |
           export NVM_DIR="${HOME}/.nvm"
           source "${NVM_DIR}/nvm.sh"
           # Look for any open PR whose body references this issue
-          PR_COUNT=$(gh pr list --state open --search "Closes #${{ github.event.issue.number }}" --json number --jq 'length')
+          PR_COUNT=$(gh pr list --repo "${{ github.repository }}" --state open --search "Closes #${{ github.event.issue.number }}" --json number --jq 'length')
           if [ "$PR_COUNT" -eq 0 ]; then
             echo "::error::Claude completed (exit 0) but no PR was created for issue #${{ github.event.issue.number }}"
             exit 1


### PR DESCRIPTION
## Summary
- The "Verify PR was created" step in the auto-implement workflow failed with `fatal: not a git repository` because it was missing `working-directory`
- Added `working-directory: /home/bahm/Projects/spaced-learning` (matching the Claude CLI step) and `--repo` flag for extra resilience

## Test plan
- [x] Unit tests pass (`npx vitest run tests/unit`)
- [x] E2E tests pass (`npx playwright test`)
- [x] Type-check clean (`npx tsc --noEmit`)

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)