### PR TITLE
fix: PWA back gesture navigates within app

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useEffect, useCallback } from 'react'
 import { ReviewSession } from './components/ReviewSession'
 import { DeckList } from './components/DeckList'
 import { DeckDetail } from './components/DeckDetail'
@@ -16,7 +16,33 @@ const TABS: { id: Tab; label: string }[] = [
 ]
 
 export default function App() {
-  const [view, setView] = useState<View>({ type: 'tab', tab: 'review' })
+  const [view, setViewState] = useState<View>({ type: 'tab', tab: 'review' })
+
+  const navigate = useCallback((newView: View) => {
+    const isSubView = newView.type === 'deck-review' || newView.type === 'deck-detail'
+    if (isSubView) {
+      history.pushState(newView, '')
+    } else {
+      history.replaceState(newView, '')
+    }
+    setViewState(newView)
+  }, [])
+
+  useEffect(() => {
+    // Set initial state so popstate has something to land on
+    history.replaceState(view, '')
+
+    const onPopState = (e: PopStateEvent) => {
+      if (e.state && typeof e.state === 'object' && 'type' in e.state) {
+        setViewState(e.state as View)
+      } else {
+        setViewState({ type: 'tab', tab: 'review' })
+      }
+    }
+    window.addEventListener('popstate', onPopState)
+    return () => window.removeEventListener('popstate', onPopState)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   const activeTab = view.type === 'tab' ? view.tab : null
   const isSubView = view.type === 'deck-review' || view.type === 'deck-detail'
@@ -27,7 +53,7 @@ export default function App() {
       <header style={{ marginBottom: '24px', display: 'flex', alignItems: 'center', gap: '12px' }}>
         {isSubView && (
           <button
-            onClick={() => setView({ type: 'tab', tab: 'decks' })}
+            onClick={() => history.back()}
             aria-label="← Decks"
             style={{ background: 'none', border: 'none', color: '#aaa', cursor: 'pointer', fontSize: '1.2rem', padding: 0 }}
           >
@@ -44,7 +70,7 @@ export default function App() {
           {TABS.map(({ id, label }) => (
             <button
               key={id}
-              onClick={() => setView({ type: 'tab', tab: id })}
+              onClick={() => navigate({ type: 'tab', tab: id })}
               aria-pressed={activeTab === id}
               style={{
                 flex: 1,
@@ -69,8 +95,8 @@ export default function App() {
         {view.type === 'tab' && activeTab === 'review' && <ReviewSession />}
         {view.type === 'tab' && activeTab === 'decks' && (
           <DeckList
-            onOpenDeck={(deckId, deckName) => setView({ type: 'deck-detail', deckId, deckName })}
-            onReviewDeck={(deckId, deckName) => setView({ type: 'deck-review', deckId, deckName })}
+            onOpenDeck={(deckId, deckName) => navigate({ type: 'deck-detail', deckId, deckName })}
+            onReviewDeck={(deckId, deckName) => navigate({ type: 'deck-review', deckId, deckName })}
           />
         )}
       </main>

--- a/tests/e2e/flashcards.spec.ts
+++ b/tests/e2e/flashcards.spec.ts
@@ -24,6 +24,43 @@ test.describe('Flashcard app', () => {
     await page.waitForTimeout(1000)
   }
 
+  // ── Browser history / back gesture ─────────────────────────────────────────
+
+  test('browser back from deck detail returns to decks list', async ({ page }) => {
+    await page.getByRole('button', { name: 'Decks' }).click()
+    await page.getByLabel('Deck name').fill('History Test')
+    await page.getByRole('button', { name: 'Add Deck' }).click()
+    await page.locator('li').filter({ hasText: 'History Test' }).getByRole('button', { name: 'Cards' }).click()
+
+    // Should be on deck detail
+    await expect(page.getByLabel('Front')).toBeVisible()
+
+    // Browser back should return to decks list, not leave the app
+    await page.goBack()
+    await expect(page.getByRole('button', { name: 'Decks' })).toBeVisible()
+    await expect(page.getByLabel('Deck name')).toBeVisible()
+  })
+
+  test('browser back from deck review returns to decks list', async ({ page }) => {
+    await page.getByRole('button', { name: 'Decks' }).click()
+    await page.getByLabel('Deck name').fill('Nav Test')
+    await page.getByRole('button', { name: 'Add Deck' }).click()
+
+    await page.locator('li').filter({ hasText: 'Nav Test' }).getByRole('button', { name: 'Cards' }).click()
+    await page.getByLabel('Front').fill('Q1')
+    await page.getByLabel('Back').fill('A1')
+    await page.getByRole('button', { name: 'Add Card' }).click()
+
+    await page.getByRole('button', { name: '← Decks' }).click()
+    await page.locator('li').filter({ hasText: 'Nav Test' }).getByRole('button', { name: 'Review' }).click()
+    await expect(page.getByText('Q1')).toBeVisible()
+
+    // Browser back should return to decks list
+    await page.goBack()
+    await expect(page.getByRole('button', { name: 'Decks' })).toBeVisible()
+    await expect(page.getByLabel('Deck name')).toBeVisible()
+  })
+
   // ── Navigation ──────────────────────────────────────────────────────────────
 
   test('only Review and Decks tabs are visible', async ({ page }) => {


### PR DESCRIPTION
## Summary
- Integrate browser History API with the app's view navigation system
- Sub-views (deck detail, deck review) push history entries; tab switches replace state
- Back button and mobile swipe-back gesture now return to the decks list instead of showing a blank page
- `popstate` listener updates React state from history entries

## Test plan
- [x] Unit tests pass (`npx vitest run tests/unit` — 37 pass)
- [x] E2E tests pass (`npx playwright test` — 28 pass, 2 new)
- [x] Type-check clean (`npx tsc --noEmit`)
- [x] New E2E: "browser back from deck detail returns to decks list"
- [x] New E2E: "browser back from deck review returns to decks list"

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)