### PR TITLE
fix: multi-sentinel history buffer for PWA back on Firefox

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,10 +31,16 @@ export default function App() {
   }, [])
 
   useEffect(() => {
-    // Replace current entry with a sentinel, then push our real state on top.
-    // This ensures back from the root lands on the sentinel (same URL, popstate fires)
-    // instead of navigating away from the app (blank screen in PWA).
-    history.replaceState(null, '')
+    // Create a deep buffer of sentinel entries to prevent back gestures from
+    // ever reaching history index 0. On some browsers (Firefox Android PWA),
+    // going back past the first entry navigates away without firing popstate.
+    // Multiple sentinels ensure we always have room to catch the back gesture.
+    const sentinel = { __sentinel: true }
+    const SENTINEL_COUNT = 5
+    history.replaceState(sentinel, '')
+    for (let i = 0; i < SENTINEL_COUNT - 1; i++) {
+      history.pushState(sentinel, '')
+    }
     history.pushState(view, '')
 
     const onPopState = (e: PopStateEvent) => {

--- a/tests/e2e/flashcards.spec.ts
+++ b/tests/e2e/flashcards.spec.ts
@@ -68,6 +68,41 @@ test.describe('Flashcard app', () => {
     await expect(page.getByRole('heading', { name: 'Spaced Learning' })).toBeVisible()
   })
 
+  test('many rapid back gestures at root do not leave the app', async ({ page }) => {
+    // Simulate aggressive back gestures (e.g., Firefox Android PWA edge swipe)
+    // With only one sentinel, this could escape the app's history stack
+    await expect(page.getByRole('heading', { name: 'Spaced Learning' })).toBeVisible()
+
+    for (let i = 0; i < 5; i++) {
+      await page.goBack()
+      await page.waitForTimeout(100)
+    }
+
+    // App must still be visible after many back gestures
+    await expect(page.getByRole('heading', { name: 'Spaced Learning' })).toBeVisible()
+  })
+
+  test('back gestures after navigating multiple sub-views do not leave the app', async ({ page }) => {
+    await page.getByRole('button', { name: 'Decks' }).click()
+    await page.getByLabel('Deck name').fill('Deep Nav')
+    await page.getByRole('button', { name: 'Add Deck' }).click()
+
+    // Navigate into sub-view and back, twice
+    for (let i = 0; i < 2; i++) {
+      await page.locator('li').filter({ hasText: 'Deep Nav' }).getByRole('button', { name: 'Cards' }).click()
+      await page.goBack()
+      await expect(page.getByRole('button', { name: 'Decks' })).toBeVisible()
+    }
+
+    // Now hammer back at root level
+    for (let i = 0; i < 3; i++) {
+      await page.goBack()
+      await page.waitForTimeout(100)
+    }
+
+    await expect(page.getByRole('heading', { name: 'Spaced Learning' })).toBeVisible()
+  })
+
   test('browser back from deck review returns to decks list', async ({ page }) => {
     await page.getByRole('button', { name: 'Decks' }).click()
     await page.getByLabel('Deck name').fill('Nav Test')


### PR DESCRIPTION
## Summary
- Replaces single `null` sentinel with 5 distinguishable sentinel entries (`{ __sentinel: true }`)
- Prevents Firefox Android PWA back gesture from reaching history index 0, which may not fire `popstate` and shows a blank screen
- Adds 2 new E2E tests: rapid back gestures at root, and back gestures after repeated sub-view navigation

## Test plan
- [x] Unit tests pass (`npx vitest run tests/unit` — 37 passed)
- [x] E2E tests pass (`npx playwright test` — 32 passed)
- [x] Type-check clean (`npx tsc --noEmit`)
- [ ] Manual verification on Firefox Android PWA: clear cache → install → edge swipe back

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)