### PR TITLE
feat: quota-aware retrospection before weekly reset

### DIFF
--- a/.claude/scripts/quota-retrospection.sh
+++ b/.claude/scripts/quota-retrospection.sh
@@ -1,0 +1,174 @@
+#!/bin/bash
+# quota-retrospection.sh
+#
+# Runs a Claude Code retrospection/self-improvement session when the weekly
+# token quota is about to reset. Designed to be called by a cron job.
+#
+# Prerequisites:
+#   - Claude Code CLI installed and authenticated (`claude` in PATH after nvm)
+#   - GitHub CLI (`gh`) authenticated
+#   - Self-hosted runner environment (local machine)
+#
+# Usage:
+#   .claude/scripts/quota-retrospection.sh          # normal run
+#   .claude/scripts/quota-retrospection.sh --force   # skip idle check and state check
+#   .claude/scripts/quota-retrospection.sh --dry-run # show what would happen without running
+#
+# Cron example (run every 15 minutes, script self-gates on time window):
+#   */15 * * * * /home/bahm/Projects/spaced-learning/.claude/scripts/quota-retrospection.sh >> /tmp/retrospection.log 2>&1
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONFIG_FILE="${SCRIPT_DIR}/retrospection-config.json"
+
+# --- Parse flags ---
+FORCE=false
+DRY_RUN=false
+for arg in "$@"; do
+  case "$arg" in
+    --force) FORCE=true ;;
+    --dry-run) DRY_RUN=true ;;
+  esac
+done
+
+# --- Source nvm ---
+export NVM_DIR="${HOME}/.nvm"
+if [ -s "${NVM_DIR}/nvm.sh" ]; then
+  source "${NVM_DIR}/nvm.sh"
+else
+  echo "ERROR: nvm not found at ${NVM_DIR}/nvm.sh"
+  exit 1
+fi
+
+# --- Load config ---
+if [ ! -f "$CONFIG_FILE" ]; then
+  echo "ERROR: Config file not found: ${CONFIG_FILE}"
+  exit 1
+fi
+
+LEAD_HOURS=$(node -e "console.log(JSON.parse(require('fs').readFileSync('${CONFIG_FILE}','utf-8')).retrospection_lead_hours)")
+MAX_BUDGET=$(node -e "console.log(JSON.parse(require('fs').readFileSync('${CONFIG_FILE}','utf-8')).max_budget_usd)")
+GITHUB_REPO=$(node -e "console.log(JSON.parse(require('fs').readFileSync('${CONFIG_FILE}','utf-8')).github_repo)")
+REPO_PATH=$(node -e "console.log(JSON.parse(require('fs').readFileSync('${CONFIG_FILE}','utf-8')).repo_path)")
+STATE_FILE=$(node -e "console.log(JSON.parse(require('fs').readFileSync('${CONFIG_FILE}','utf-8')).state_file)")
+RETRO_PROMPT=$(node -e "console.log(JSON.parse(require('fs').readFileSync('${CONFIG_FILE}','utf-8')).retrospection_prompt)")
+
+# --- Determine quota reset time ---
+# The quota resets weekly. We parse the cron expression to find the next reset.
+# For simplicity, we extract day-of-week (0=Sun..6=Sat) and hour from the cron.
+RESET_CRON=$(node -e "console.log(JSON.parse(require('fs').readFileSync('${CONFIG_FILE}','utf-8')).quota_reset_cron)")
+RESET_DOW=$(echo "$RESET_CRON" | awk '{print $5}')  # day of week
+RESET_HOUR=$(echo "$RESET_CRON" | awk '{print $2}')  # hour
+
+CURRENT_DOW=$(date +%u)  # 1=Mon..7=Sun (ISO)
+CURRENT_HOUR=$(date +%H)
+
+# Convert cron DOW (0=Sun, 5=Fri) to ISO DOW (1=Mon..7=Sun)
+if [ "$RESET_DOW" -eq 0 ]; then
+  RESET_DOW_ISO=7
+else
+  RESET_DOW_ISO=$RESET_DOW
+fi
+
+# Calculate hours until reset
+HOURS_UNTIL_RESET=$(( (RESET_DOW_ISO - CURRENT_DOW) * 24 + (RESET_HOUR - CURRENT_HOUR) ))
+if [ "$HOURS_UNTIL_RESET" -lt 0 ]; then
+  HOURS_UNTIL_RESET=$((HOURS_UNTIL_RESET + 168))  # wrap to next week
+fi
+
+echo "$(date '+%Y-%m-%d %H:%M:%S') — Quota retrospection check"
+echo "  Hours until reset: ${HOURS_UNTIL_RESET}"
+echo "  Lead window: ${LEAD_HOURS}h"
+echo "  Max budget: \$${MAX_BUDGET}"
+
+# --- Check if we're in the retrospection window ---
+if [ "$FORCE" = false ] && [ "$HOURS_UNTIL_RESET" -gt "$LEAD_HOURS" ]; then
+  echo "  Not in retrospection window (${HOURS_UNTIL_RESET}h > ${LEAD_HOURS}h). Skipping."
+  exit 0
+fi
+
+echo "  ✓ In retrospection window"
+
+# --- Check state file for last run ---
+if [ "$FORCE" = false ] && [ -f "$STATE_FILE" ]; then
+  LAST_RUN_EPOCH=$(node -e "
+    const s = JSON.parse(require('fs').readFileSync('${STATE_FILE}','utf-8'));
+    console.log(s.last_run_epoch || 0)
+  ")
+  CURRENT_EPOCH=$(date +%s)
+  # Don't run again if last run was less than LEAD_HOURS ago
+  COOLDOWN_SECONDS=$((LEAD_HOURS * 3600))
+  ELAPSED=$((CURRENT_EPOCH - LAST_RUN_EPOCH))
+  if [ "$ELAPSED" -lt "$COOLDOWN_SECONDS" ]; then
+    echo "  Already ran ${ELAPSED}s ago (cooldown: ${COOLDOWN_SECONDS}s). Skipping."
+    exit 0
+  fi
+fi
+
+echo "  ✓ No recent run in state file"
+
+# --- Check if self-hosted runner is idle ---
+# Look for in-progress workflow runs on the repo
+if [ "$FORCE" = false ]; then
+  ACTIVE_RUNS=$(gh run list --repo "$GITHUB_REPO" --status in_progress --json databaseId --jq 'length' 2>/dev/null || echo "0")
+  if [ "$ACTIVE_RUNS" -gt 0 ]; then
+    echo "  Runner busy (${ACTIVE_RUNS} active workflow runs). Skipping."
+    exit 0
+  fi
+  echo "  ✓ Runner is idle"
+fi
+
+# --- Dry run check ---
+if [ "$DRY_RUN" = true ]; then
+  echo "  [DRY RUN] Would launch retrospection with budget \$${MAX_BUDGET}"
+  echo "  Prompt: ${RETRO_PROMPT:0:100}..."
+  exit 0
+fi
+
+# --- Update state file ---
+mkdir -p "$(dirname "$STATE_FILE")"
+node -e "
+  const fs = require('fs');
+  const state = { last_run_epoch: Math.floor(Date.now()/1000), last_run_iso: new Date().toISOString() };
+  fs.writeFileSync('${STATE_FILE}', JSON.stringify(state, null, 2));
+"
+echo "  ✓ State file updated"
+
+# --- Run Claude Code retrospection ---
+echo "  Launching Claude Code retrospection..."
+cd "$REPO_PATH"
+
+# Ensure we're on main with latest
+git checkout main
+git pull
+
+# Create a retrospection branch
+BRANCH_NAME="chore/retrospection-$(date +%Y%m%d-%H%M)"
+git checkout -b "$BRANCH_NAME"
+
+# Unset GH_TOKEN to use personal gh auth (avoid restricted Actions token)
+unset GH_TOKEN 2>/dev/null || true
+
+claude --dangerously-skip-permissions -p "${RETRO_PROMPT}" \
+  --max-budget-usd "$MAX_BUDGET" \
+  --allowedTools "Bash,Read,Edit,Write,Glob,Grep" \
+  2>&1 | tee /tmp/retrospection-output.log
+
+CLAUDE_EXIT=$?
+
+echo "  Claude exited with code: ${CLAUDE_EXIT}"
+
+# --- Verify a PR was created ---
+PR_EXISTS=$(gh pr list --repo "$GITHUB_REPO" --head "$BRANCH_NAME" --state open --json number --jq 'length' 2>/dev/null || echo "0")
+
+if [ "$PR_EXISTS" -eq 0 ]; then
+  echo "  ⚠ No PR was created. Check /tmp/retrospection-output.log for details."
+  # Clean up the branch if empty
+  git checkout main
+  git branch -D "$BRANCH_NAME" 2>/dev/null || true
+else
+  echo "  ✓ PR created successfully"
+fi
+
+echo "$(date '+%Y-%m-%d %H:%M:%S') — Retrospection complete"

--- a/.claude/scripts/retrospection-config.json
+++ b/.claude/scripts/retrospection-config.json
@@ -1,0 +1,9 @@
+{
+  "quota_reset_cron": "0 0 * * 5",
+  "retrospection_lead_hours": 2,
+  "max_budget_usd": 5.00,
+  "github_repo": "Bahm/spaced-learning",
+  "repo_path": "/home/bahm/Projects/spaced-learning",
+  "state_file": "/tmp/spaced-learning-retrospection-state.json",
+  "retrospection_prompt": "You are running a scheduled retrospection session on the spaced-learning project. Your weekly token quota is about to reset, so use this time productively.\n\nPriority order:\n1. Run the full test suite and fix any failures\n2. Run `npx tsc --noEmit` and fix any type errors\n3. Review CLAUDE.md and MEMORY.md for stale or contradictory entries\n4. Look for code quality improvements: unused imports, dead code, inconsistent patterns\n5. Check if any dependencies have security advisories (`npm audit`)\n6. Review open GitHub issues for low-hanging fruit\n\nConstraints:\n- Follow TDD: write a failing test before any code change\n- Follow the architecture layering (domain → db → hooks → components)\n- Create a single PR with all improvements, titled 'chore: scheduled retrospection'\n- Keep changes focused and reviewable — prefer 3 solid fixes over 10 superficial ones\n- Do NOT make breaking changes or large refactors\n- Always source nvm: export NVM_DIR=\"${HOME}/.nvm\"; source \"${NVM_DIR}/nvm.sh\""
+}

--- a/.github/RUNNER_SETUP.md
+++ b/.github/RUNNER_SETUP.md
@@ -63,6 +63,56 @@ A comment is posted to the issue when Claude starts. If the run fails, a failure
 
 Any repository collaborator with permission to add labels can trigger an automated run. Restrict who can add labels via GitHub's repository role settings if needed. The runner process runs as your local user account, so it has full access to your machine.
 
+## Quota-aware retrospection (cron job)
+
+The project includes a script that runs Claude Code for self-improvement before the weekly token quota resets. When most of the quota would otherwise go unused, this reclaims it for code quality work.
+
+### How it works
+
+1. A cron job runs `.claude/scripts/quota-retrospection.sh` every 15 minutes
+2. The script checks if we're within the configured lead time before quota reset (default: 2 hours)
+3. If the runner is idle (no active GitHub Actions workflow runs), it launches a Claude Code session
+4. The session has a `--max-budget-usd` cap to avoid over-spending
+5. A state file prevents duplicate runs in the same reset cycle
+
+### Setup
+
+Edit the config to match your quota reset schedule:
+
+```bash
+# .claude/scripts/retrospection-config.json
+# quota_reset_cron: cron expression for when your quota resets (default: Friday midnight)
+# retrospection_lead_hours: how many hours before reset to start (default: 2)
+# max_budget_usd: spending cap per retrospection session (default: 5.00)
+```
+
+Install the cron job:
+
+```bash
+# Run every 15 minutes — the script self-gates on the time window
+(crontab -l 2>/dev/null; echo "*/15 * * * * /home/bahm/Projects/spaced-learning/.claude/scripts/quota-retrospection.sh >> /tmp/retrospection.log 2>&1") | crontab -
+```
+
+Verify:
+
+```bash
+crontab -l | grep retrospection
+```
+
+### Manual usage
+
+```bash
+npm run retrospection:dry    # Preview what would happen
+npm run retrospection:force  # Run immediately, skip time/idle checks
+npm run retrospection        # Normal run (respects time window)
+```
+
+### Limitations
+
+- **No direct quota API**: The Claude Code CLI doesn't expose subscription quota usage. The script uses a time-based heuristic (run N hours before reset) rather than checking actual remaining percentage.
+- **Budget cap as proxy**: `--max-budget-usd` caps spending per session but doesn't map 1:1 to subscription tokens.
+- **Requires `gh` auth**: The script uses `gh` to check runner status and create PRs. Ensure `gh auth login` is configured.
+
 ## Stopping the runner
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -13,7 +13,10 @@
     "test:coverage": "vitest run --coverage",
     "test:e2e": "playwright test",
     "lint": "eslint src",
-    "memory:sync": "bash .claude/scripts/post-session.sh"
+    "memory:sync": "bash .claude/scripts/post-session.sh",
+    "retrospection": "bash .claude/scripts/quota-retrospection.sh",
+    "retrospection:dry": "bash .claude/scripts/quota-retrospection.sh --dry-run",
+    "retrospection:force": "bash .claude/scripts/quota-retrospection.sh --force"
   },
   "repository": {
     "type": "git",

--- a/tests/unit/claudeRules.test.ts
+++ b/tests/unit/claudeRules.test.ts
@@ -1,9 +1,11 @@
 import { describe, it, expect } from 'vitest'
-import { readFileSync, readdirSync, existsSync } from 'fs'
+import { readFileSync, readdirSync, existsSync, accessSync, constants } from 'fs'
 import { join } from 'path'
 
 const RULES_DIR = join(__dirname, '../../.claude/rules')
 const SKILL_PATH = join(__dirname, '../../.claude/skills/implement-issue/SKILL.md')
+const RETRO_SCRIPT = join(__dirname, '../../.claude/scripts/quota-retrospection.sh')
+const RETRO_CONFIG = join(__dirname, '../../.claude/scripts/retrospection-config.json')
 
 describe('.claude/rules/ structure', () => {
   it('rules directory exists', () => {
@@ -52,5 +54,55 @@ describe('implement-issue skill best-practices audit', () => {
     expect(step9Match, 'step 9 must exist').not.toBeNull()
     const step9Content = step9Match![1]!
     expect(step9Content).toMatch(/best.practices audit/i)
+  })
+})
+
+describe('quota-aware retrospection infrastructure', () => {
+  it('config file exists and is valid JSON', () => {
+    expect(existsSync(RETRO_CONFIG)).toBe(true)
+    const config = JSON.parse(readFileSync(RETRO_CONFIG, 'utf-8'))
+    expect(config).toBeDefined()
+  })
+
+  it('config has required fields', () => {
+    const config = JSON.parse(readFileSync(RETRO_CONFIG, 'utf-8'))
+    expect(config).toHaveProperty('quota_reset_cron')
+    expect(config).toHaveProperty('retrospection_lead_hours')
+    expect(config).toHaveProperty('max_budget_usd')
+    expect(config).toHaveProperty('github_repo')
+    expect(config).toHaveProperty('repo_path')
+  })
+
+  it('config values are within reasonable ranges', () => {
+    const config = JSON.parse(readFileSync(RETRO_CONFIG, 'utf-8'))
+    expect(config.retrospection_lead_hours).toBeGreaterThan(0)
+    expect(config.retrospection_lead_hours).toBeLessThanOrEqual(24)
+    expect(config.max_budget_usd).toBeGreaterThan(0)
+    expect(config.max_budget_usd).toBeLessThanOrEqual(50)
+  })
+
+  it('retrospection script exists and is executable', () => {
+    expect(existsSync(RETRO_SCRIPT)).toBe(true)
+    expect(() => accessSync(RETRO_SCRIPT, constants.X_OK)).not.toThrow()
+  })
+
+  it('script sources nvm before running node/claude commands', () => {
+    const script = readFileSync(RETRO_SCRIPT, 'utf-8')
+    expect(script).toContain('nvm.sh')
+  })
+
+  it('script checks runner idle status before launching', () => {
+    const script = readFileSync(RETRO_SCRIPT, 'utf-8')
+    expect(script).toMatch(/gh.*run.*list|workflow.*run/i)
+  })
+
+  it('script uses a state file to prevent duplicate runs per cycle', () => {
+    const script = readFileSync(RETRO_SCRIPT, 'utf-8')
+    expect(script).toMatch(/state|lock|last.run/i)
+  })
+
+  it('script passes --max-budget-usd to claude CLI', () => {
+    const script = readFileSync(RETRO_SCRIPT, 'utf-8')
+    expect(script).toContain('--max-budget-usd')
   })
 })


### PR DESCRIPTION
## Summary
- Adds a cron-compatible script (`.claude/scripts/quota-retrospection.sh`) that launches Claude Code for self-improvement work when the weekly token quota is about to reset
- Time-based trigger (configurable lead hours before reset) since the Claude Code CLI has no quota API
- Guards: checks runner is idle (no active workflow runs), uses state file to prevent duplicate runs per cycle, caps spending with `--max-budget-usd`
- Config file (`.claude/scripts/retrospection-config.json`) for reset schedule, budget, repo path
- npm scripts: `retrospection`, `retrospection:dry`, `retrospection:force`
- Setup instructions added to `RUNNER_SETUP.md`

## Limitations
- No direct quota percentage API exists — uses time-based heuristic instead of checking "80% remaining"
- `--max-budget-usd` is a spending cap proxy, not a direct token quota check

## Test plan
- [x] Unit tests pass (`npx vitest run tests/unit` — 45 tests including 8 new infrastructure tests)
- [x] E2E tests pass (`npx playwright test` — 32 tests)
- [x] Type-check clean (`npx tsc --noEmit`)

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)