### PR TITLE
feat: auto-resume when token quota reached during auto-implement

### DIFF
--- a/.claude/scripts/quota-retry-wrapper.sh
+++ b/.claude/scripts/quota-retry-wrapper.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# quota-retry-wrapper.sh — Wraps claude CLI with automatic retry on quota exhaustion.
+#
+# When the Claude CLI exits due to a token quota limit, this script:
+# 1. Detects the quota error in stdout/stderr
+# 2. Parses the reset time from the error message
+# 3. Waits until the quota resets (+ 60s buffer)
+# 4. Retries the command
+#
+# Usage: ./quota-retry-wrapper.sh <issue_number> <github_repo> <claude_args...>
+#   issue_number  — GitHub issue number (for posting status comments, or "none" to skip)
+#   github_repo   — GitHub repo in owner/repo format (or "none" to skip comments)
+#   claude_args   — remaining args passed directly to `claude`
+#
+# Environment:
+#   ANTHROPIC_API_KEY — required by claude CLI
+#   MAX_RETRIES       — max quota retries (default: 2)
+#   DEFAULT_WAIT_SECS — fallback wait if reset time can't be parsed (default: 3600)
+
+set -euo pipefail
+
+ISSUE_NUMBER="${1:?Usage: $0 <issue_number> <github_repo> <claude_args...>}"
+GITHUB_REPO="${2:?Usage: $0 <issue_number> <github_repo> <claude_args...>}"
+shift 2
+
+MAX_RETRIES="${MAX_RETRIES:-2}"
+DEFAULT_WAIT_SECS="${DEFAULT_WAIT_SECS:-3600}"
+RETRY_COUNT=0
+
+# Post a comment on the GitHub issue (if issue number and repo are provided)
+post_comment() {
+  local body="$1"
+  if [ "$ISSUE_NUMBER" != "none" ] && [ "$GITHUB_REPO" != "none" ] && command -v gh &>/dev/null; then
+    gh issue comment "$ISSUE_NUMBER" --repo "$GITHUB_REPO" --body "$body" 2>/dev/null || true
+  fi
+}
+
+# Parse reset time from Claude CLI output.
+# Matches patterns like:
+#   "reset at 2026-03-16T00:00:00Z"
+#   "resets on March 16, 2026"
+#   "reset at 12:00 AM UTC on March 16"
+#   "will reset on 2026-03-16 00:00:00"
+parse_reset_time() {
+  local output="$1"
+  local reset_str
+
+  # Try ISO 8601 timestamp first (most reliable)
+  reset_str=$(echo "$output" | grep -oP '\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[A-Z]*' | head -1)
+  if [ -n "$reset_str" ]; then
+    echo "$reset_str"
+    return 0
+  fi
+
+  # Try "YYYY-MM-DD HH:MM:SS" format
+  reset_str=$(echo "$output" | grep -oP '\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}' | head -1)
+  if [ -n "$reset_str" ]; then
+    echo "$reset_str"
+    return 0
+  fi
+
+  # Try natural language date after "reset at/on"
+  reset_str=$(echo "$output" | grep -oiP '(?:reset(?:s)?|renew(?:s)?)\s+(?:at|on)\s+\K[^\n.!]+' | head -1)
+  if [ -n "$reset_str" ]; then
+    echo "$reset_str"
+    return 0
+  fi
+
+  return 1
+}
+
+# Detect if the output contains a quota/rate-limit error
+is_quota_error() {
+  local output="$1"
+  echo "$output" | grep -qiP 'quota|rate.limit|token.limit|usage.limit|billing|credit|exceeded.*limit'
+}
+
+# Calculate seconds to wait until the parsed reset time
+calculate_wait_secs() {
+  local reset_str="$1"
+  local reset_epoch now_epoch wait_secs
+
+  reset_epoch=$(date -d "$reset_str" +%s 2>/dev/null) || return 1
+  now_epoch=$(date +%s)
+
+  if [ "$reset_epoch" -le "$now_epoch" ]; then
+    # Reset time is in the past — use default wait
+    return 1
+  fi
+
+  wait_secs=$(( reset_epoch - now_epoch + 60 ))  # 60s buffer
+  echo "$wait_secs"
+  return 0
+}
+
+# Temporary file for capturing output (cleaned up on exit)
+OUTPUT_FILE=$(mktemp)
+trap 'rm -f "$OUTPUT_FILE"' EXIT
+
+while true; do
+  echo "--- Running claude CLI (attempt $((RETRY_COUNT + 1))/$((MAX_RETRIES + 1))) ---"
+
+  # Run claude, tee output for both display and capture
+  set +e
+  claude "$@" 2>&1 | tee "$OUTPUT_FILE"
+  EXIT_CODE=${PIPESTATUS[0]}
+  set -e
+
+  if [ "$EXIT_CODE" -eq 0 ]; then
+    exit 0
+  fi
+
+  OUTPUT=$(cat "$OUTPUT_FILE")
+
+  # Check if this is a quota error
+  if is_quota_error "$OUTPUT"; then
+    RETRY_COUNT=$((RETRY_COUNT + 1))
+    if [ "$RETRY_COUNT" -gt "$MAX_RETRIES" ]; then
+      echo "::error::Max quota retries ($MAX_RETRIES) exceeded. Giving up."
+      post_comment "❌ **Claude Code** hit the token quota $((MAX_RETRIES + 1)) times and gave up. Manual intervention needed."
+      exit 1
+    fi
+
+    # Try to parse reset time
+    WAIT_SECS="$DEFAULT_WAIT_SECS"
+    if RESET_STR=$(parse_reset_time "$OUTPUT"); then
+      if PARSED_WAIT=$(calculate_wait_secs "$RESET_STR"); then
+        WAIT_SECS="$PARSED_WAIT"
+        echo "Quota reset time detected: $RESET_STR"
+      else
+        echo "Could not calculate wait from reset time '$RESET_STR'. Using default wait."
+      fi
+    else
+      echo "Could not parse quota reset time from output. Using default wait of ${DEFAULT_WAIT_SECS}s."
+    fi
+
+    RESUME_TIME=$(date -d "+${WAIT_SECS} seconds" '+%Y-%m-%d %H:%M:%S %Z')
+    echo "⏳ Waiting ${WAIT_SECS}s for quota reset (resuming at $RESUME_TIME)..."
+    post_comment "⏳ **Claude Code** hit the token quota. Waiting for quota reset — will auto-resume at **$RESUME_TIME** (attempt $RETRY_COUNT/$MAX_RETRIES)."
+
+    sleep "$WAIT_SECS"
+
+    echo "⏰ Wait complete. Retrying..."
+    post_comment "🔄 **Claude Code** is resuming work on this issue after quota reset (attempt $((RETRY_COUNT + 1))/$((MAX_RETRIES + 1)))."
+  else
+    # Non-quota error — don't retry
+    echo "Claude exited with code $EXIT_CODE (not a quota error). Not retrying."
+    exit "$EXIT_CODE"
+  fi
+done

--- a/.github/RUNNER_SETUP.md
+++ b/.github/RUNNER_SETUP.md
@@ -63,6 +63,22 @@ A comment is posted to the issue when Claude starts. If the run fails, a failure
 
 Any repository collaborator with permission to add labels can trigger an automated run. Restrict who can add labels via GitHub's repository role settings if needed. The runner process runs as your local user account, so it has full access to your machine.
 
+## Quota auto-retry
+
+The workflow uses `.claude/scripts/quota-retry-wrapper.sh` to automatically handle token quota exhaustion. When the Claude CLI exits due to a quota limit:
+
+1. The wrapper detects the quota error in the output
+2. Parses the reset time from the error message (ISO 8601, datetime, or natural language)
+3. Posts a status comment on the GitHub issue
+4. Sleeps until the quota resets (+ 60s buffer)
+5. Retries the full command
+
+Configuration via environment variables in the workflow:
+- `MAX_RETRIES` — number of quota retries (default: 2)
+- `DEFAULT_WAIT_SECS` — fallback wait if reset time can't be parsed (default: 3600s = 1 hour)
+
+The workflow timeout is set to 360 minutes (6 hours) to accommodate quota waits. GitHub Actions enforces a hard limit of 6 hours per job.
+
 ## Stopping the runner
 
 ```bash

--- a/.github/workflows/implement-from-issue.yml
+++ b/.github/workflows/implement-from-issue.yml
@@ -5,6 +5,9 @@ name: Implement Issue via Claude Code CLI
 # (this machine), which executes the full implement-issue TDD workflow
 # locally and opens a PR that closes the issue.
 #
+# If the token quota is reached, the quota-retry-wrapper automatically
+# waits for the quota reset and retries (up to MAX_RETRIES times).
+#
 # Setup: see .github/RUNNER_SETUP.md
 
 on:
@@ -21,7 +24,7 @@ jobs:
     name: implement-issue #${{ github.event.issue.number }}
     if: github.event.label.name == 'auto-implement'
     runs-on: self-hosted
-    timeout-minutes: 60
+    timeout-minutes: 360
 
     steps:
       - name: Check actor permissions
@@ -45,19 +48,23 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: '🤖 **Claude Code** is starting work on this issue. A PR will be created when done.'
+              body: '🤖 **Claude Code** is starting work on this issue. A PR will be created when done.\n\nIf the token quota is reached, the runner will automatically wait for quota reset and resume.'
             })
 
-      - name: Run implement-issue via Claude Code CLI
+      - name: Run implement-issue via quota-retry-wrapper
         working-directory: /home/bahm/Projects/spaced-learning
         run: |
           export NVM_DIR="${HOME}/.nvm"
           source "${NVM_DIR}/nvm.sh"
-          claude --dangerously-skip-permissions -p \
+          unset GH_TOKEN
+          .claude/scripts/quota-retry-wrapper.sh \
+            "${{ github.event.issue.number }}" \
+            "${{ github.repository }}" \
+            --dangerously-skip-permissions -p \
             "/implement-issue #${{ github.event.issue.number }}. You MUST complete the full workflow: write failing tests, implement, verify, commit, and open a PR. Do not stop at planning."
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          GH_TOKEN: ${{ github.token }}
+          MAX_RETRIES: "2"
 
       - name: Verify PR was created
         working-directory: /home/bahm/Projects/spaced-learning

--- a/tests/unit/claudeRules.test.ts
+++ b/tests/unit/claudeRules.test.ts
@@ -4,6 +4,8 @@ import { join } from 'path'
 
 const RULES_DIR = join(__dirname, '../../.claude/rules')
 const SKILL_PATH = join(__dirname, '../../.claude/skills/implement-issue/SKILL.md')
+const WRAPPER_SCRIPT_PATH = join(__dirname, '../../.claude/scripts/quota-retry-wrapper.sh')
+const WORKFLOW_PATH = join(__dirname, '../../.github/workflows/implement-from-issue.yml')
 
 describe('.claude/rules/ structure', () => {
   it('rules directory exists', () => {
@@ -52,5 +54,52 @@ describe('implement-issue skill best-practices audit', () => {
     expect(step9Match, 'step 9 must exist').not.toBeNull()
     const step9Content = step9Match![1]!
     expect(step9Content).toMatch(/best.practices audit/i)
+  })
+})
+
+describe('quota-retry wrapper script', () => {
+  it('quota-retry-wrapper.sh exists', () => {
+    expect(existsSync(WRAPPER_SCRIPT_PATH)).toBe(true)
+  })
+
+  it('contains quota error detection logic', () => {
+    const content = readFileSync(WRAPPER_SCRIPT_PATH, 'utf-8')
+    expect(content).toMatch(/quota|rate.limit|token.limit/i)
+  })
+
+  it('contains retry loop with max retries', () => {
+    const content = readFileSync(WRAPPER_SCRIPT_PATH, 'utf-8')
+    expect(content).toMatch(/MAX_RETRIES/)
+    expect(content).toMatch(/while|for/)
+  })
+
+  it('parses reset time from error output', () => {
+    const content = readFileSync(WRAPPER_SCRIPT_PATH, 'utf-8')
+    expect(content).toMatch(/reset/i)
+    expect(content).toMatch(/date|sleep/)
+  })
+
+  it('is executable (has shebang)', () => {
+    const content = readFileSync(WRAPPER_SCRIPT_PATH, 'utf-8')
+    expect(content.startsWith('#!/')).toBe(true)
+  })
+})
+
+describe('implement-from-issue workflow uses quota retry', () => {
+  const workflowContent = readFileSync(WORKFLOW_PATH, 'utf-8')
+
+  it('references the quota-retry-wrapper script', () => {
+    expect(workflowContent).toMatch(/quota-retry-wrapper/)
+  })
+
+  it('has timeout sufficient for quota retry waits', () => {
+    const timeoutMatch = workflowContent.match(/timeout-minutes:\s*(\d+)/)
+    expect(timeoutMatch).not.toBeNull()
+    const timeout = parseInt(timeoutMatch![1]!, 10)
+    expect(timeout).toBeGreaterThanOrEqual(180)
+  })
+
+  it('posts a comment when waiting for quota reset', () => {
+    expect(workflowContent).toMatch(/quota.*reset|waiting.*quota/i)
   })
 })


### PR DESCRIPTION
## Summary
- Adds `quota-retry-wrapper.sh` that wraps Claude CLI calls with automatic retry on token quota exhaustion
- Wrapper detects quota errors in CLI output, parses the reset time (ISO 8601, datetime, or natural language), waits, and retries
- Posts status comments on the GitHub issue when waiting for quota reset and when resuming
- Workflow timeout increased from 60 to 360 minutes to accommodate wait periods
- Configurable via `MAX_RETRIES` (default: 2) and `DEFAULT_WAIT_SECS` (default: 3600) env vars
- Also fixes `GH_TOKEN` override issue by unsetting it before the Claude CLI step

## Test plan
- [x] Unit tests pass (`npx vitest run tests/unit`) — 45 tests including 8 new tests for wrapper script structure and workflow configuration
- [x] E2E tests pass (`npx playwright test`) — 32 tests
- [x] Type-check clean (`npx tsc --noEmit`)

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)