### PR TITLE
feat: pre-reset retrospection before weekly quota reset

### DIFF
--- a/.claude/scripts/pre-reset-retrospection.sh
+++ b/.claude/scripts/pre-reset-retrospection.sh
@@ -1,0 +1,235 @@
+#!/usr/bin/env bash
+# pre-reset-retrospection.sh — Run retrospection/self-improvement before weekly quota reset.
+#
+# Designed to be run by cron every 15 minutes. The script checks whether we're
+# within the configured time window before the weekly quota reset. If so, and
+# the runner is idle, it launches Claude Code for quality-focused retrospection
+# and creates a PR with any improvements.
+#
+# Usage: ./pre-reset-retrospection.sh [--dry-run] [--force]
+#   --dry-run   Print what would happen without running Claude
+#   --force     Skip the time-window check (still checks idle)
+#
+# Config: .claude/scripts/retrospection-config.json
+#   resetDay      — day of week quota resets (e.g. "Monday")
+#   resetHourUTC  — hour (0-23) quota resets in UTC
+#   windowHours   — hours before reset to start retrospection
+#   maxBudgetUsd  — --max-budget-usd cap for the Claude session
+#   tasks         — list of retrospection task descriptions
+#
+# Cron example (every 15 min):
+#   */15 * * * * cd /home/bahm/Projects/spaced-learning && .claude/scripts/pre-reset-retrospection.sh >> /tmp/pre-reset-retrospection.log 2>&1
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+CONFIG_FILE="$SCRIPT_DIR/retrospection-config.json"
+LOCK_FILE="/tmp/pre-reset-retrospection.lock"
+
+# Parse flags
+DRY_RUN=false
+FORCE=false
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=true ;;
+    --force)   FORCE=true ;;
+  esac
+done
+
+# --- Config ---
+
+if [ ! -f "$CONFIG_FILE" ]; then
+  echo "ERROR: Config file not found: $CONFIG_FILE"
+  exit 1
+fi
+
+RESET_DAY=$(python3 -c "import json; print(json.load(open('$CONFIG_FILE'))['resetDay'])")
+RESET_HOUR_UTC=$(python3 -c "import json; print(json.load(open('$CONFIG_FILE'))['resetHourUTC'])")
+WINDOW_HOURS=$(python3 -c "import json; print(json.load(open('$CONFIG_FILE'))['windowHours'])")
+MAX_BUDGET=$(python3 -c "import json; print(json.load(open('$CONFIG_FILE'))['maxBudgetUsd'])")
+TASKS=$(python3 -c "
+import json
+tasks = json.load(open('$CONFIG_FILE'))['tasks']
+print('\n'.join(f'- {t}' for t in tasks))
+")
+
+# --- Time window check ---
+
+# Calculate next reset time and check if we're in the window
+in_retrospection_window() {
+  local now_epoch reset_epoch window_start_epoch
+  now_epoch=$(date +%s)
+
+  # Find the next occurrence of RESET_DAY at RESET_HOUR_UTC
+  # Start from today, check up to 7 days ahead
+  for i in $(seq 0 7); do
+    local candidate
+    candidate=$(date -u -d "+${i} days" +%Y-%m-%d)
+    local candidate_day
+    candidate_day=$(date -u -d "$candidate" +%A)
+    if [ "$candidate_day" = "$RESET_DAY" ]; then
+      reset_epoch=$(date -u -d "${candidate} ${RESET_HOUR_UTC}:00:00" +%s)
+      # If the reset time is in the past (earlier today), try next week
+      if [ "$reset_epoch" -le "$now_epoch" ] && [ "$i" -eq 0 ]; then
+        continue
+      fi
+      break
+    fi
+  done
+
+  if [ -z "${reset_epoch:-}" ]; then
+    echo "Could not determine next reset time for $RESET_DAY"
+    return 1
+  fi
+
+  window_start_epoch=$((reset_epoch - WINDOW_HOURS * 3600))
+  local hours_until_reset=$(( (reset_epoch - now_epoch) / 3600 ))
+
+  if [ "$now_epoch" -ge "$window_start_epoch" ] && [ "$now_epoch" -lt "$reset_epoch" ]; then
+    echo "In retrospection window: ${hours_until_reset}h until reset (window: ${WINDOW_HOURS}h before)"
+    return 0
+  else
+    echo "Outside retrospection window: ${hours_until_reset}h until reset (window starts ${WINDOW_HOURS}h before)"
+    return 1
+  fi
+}
+
+# --- Idle check ---
+
+# Check if the runner is idle (no other Claude or implement-issue process running)
+is_runner_idle() {
+  # Check for lock file from a previous run
+  if [ -f "$LOCK_FILE" ]; then
+    local lock_pid
+    lock_pid=$(cat "$LOCK_FILE" 2>/dev/null || echo "")
+    if [ -n "$lock_pid" ] && kill -0 "$lock_pid" 2>/dev/null; then
+      echo "Runner is busy: previous retrospection still running (PID $lock_pid)"
+      return 1
+    else
+      # Stale lock file — clean up
+      rm -f "$LOCK_FILE"
+    fi
+  fi
+
+  # Check for any running Claude CLI processes (implement-issue or other)
+  if pgrep -f "claude.*--dangerously-skip-permissions" >/dev/null 2>&1; then
+    echo "Runner is busy: another Claude CLI session is active"
+    return 1
+  fi
+
+  echo "Runner is idle"
+  return 0
+}
+
+# --- Main ---
+
+echo "=== Pre-reset retrospection check: $(date) ==="
+
+# Check time window (skip with --force)
+if [ "$FORCE" = false ]; then
+  if ! in_retrospection_window; then
+    echo "Skipping: not in retrospection window"
+    exit 0
+  fi
+else
+  echo "Force mode: skipping time-window check"
+fi
+
+# Check if runner is idle
+if ! is_runner_idle; then
+  echo "Skipping: runner is not idle"
+  exit 0
+fi
+
+# Create lock file
+echo $$ > "$LOCK_FILE"
+trap 'rm -f "$LOCK_FILE"' EXIT
+
+BRANCH_NAME="chore/pre-reset-retrospection-$(date +%Y%m%d-%H%M)"
+
+if [ "$DRY_RUN" = true ]; then
+  echo ""
+  echo "=== DRY RUN ==="
+  echo "Would create branch: $BRANCH_NAME"
+  echo "Would run Claude with --max-budget-usd $MAX_BUDGET"
+  echo "Tasks:"
+  echo "$TASKS"
+  echo "==============="
+  exit 0
+fi
+
+# Source nvm
+export NVM_DIR="${HOME}/.nvm"
+# shellcheck source=/dev/null
+source "${NVM_DIR}/nvm.sh"
+
+cd "$PROJECT_DIR"
+
+# Ensure we're on a clean main
+git checkout main
+git pull
+
+# Create retrospection branch
+git checkout -b "$BRANCH_NAME"
+
+echo "Starting retrospection with --max-budget-usd $MAX_BUDGET..."
+
+# Run Claude for retrospection
+# Use quota-retry-wrapper if available, otherwise direct
+PROMPT="You are running a pre-reset retrospection session on the spaced-learning project.
+Your weekly token quota resets soon. Use the remaining budget for quality improvements.
+
+Focus on these tasks (in priority order):
+$TASKS
+
+Rules:
+- Run npx tsc --noEmit and npx vitest run tests/unit before and after changes
+- Only commit changes that pass type-check and tests
+- Keep changes focused and atomic — one concern per commit
+- Do NOT add new features — this is maintenance and quality only
+- When done, commit all changes with descriptive messages
+
+After making improvements, create a PR with:
+  gh pr create --title 'chore: pre-reset retrospection $(date +%Y-%m-%d)' --body 'Automated quality improvements before weekly quota reset.'
+"
+
+unset GH_TOKEN
+claude --dangerously-skip-permissions \
+  --max-budget-usd "$MAX_BUDGET" \
+  -p "$PROMPT" || {
+    EXIT_CODE=$?
+    echo "Claude exited with code $EXIT_CODE"
+    # If there are uncommitted changes, commit them before giving up
+    if [ -n "$(git status --porcelain)" ]; then
+      echo "Committing remaining changes before exit..."
+      git add -A
+      git commit -m "chore: partial retrospection (Claude exited with code $EXIT_CODE)"
+      git push -u origin "$BRANCH_NAME"
+      gh pr create \
+        --title "chore: pre-reset retrospection $(date +%Y-%m-%d) (partial)" \
+        --body "Automated quality improvements before weekly quota reset. Claude exited early (code $EXIT_CODE)."
+    fi
+    exit "$EXIT_CODE"
+  }
+
+# Verify a PR was created
+PR_COUNT=$(gh pr list --state open --head "$BRANCH_NAME" --json number --jq 'length')
+if [ "$PR_COUNT" -eq 0 ]; then
+  echo "Claude finished but no PR was created. Checking for changes..."
+  if [ -n "$(git diff main --stat)" ]; then
+    echo "Changes exist but no PR — creating one now."
+    git push -u origin "$BRANCH_NAME"
+    gh pr create \
+      --title "chore: pre-reset retrospection $(date +%Y-%m-%d)" \
+      --body "Automated quality improvements before weekly quota reset."
+  else
+    echo "No changes were made. Nothing to do."
+    git checkout main
+    git branch -d "$BRANCH_NAME"
+  fi
+else
+  echo "PR created successfully."
+fi
+
+echo "=== Retrospection complete: $(date) ==="

--- a/.claude/scripts/retrospection-config.json
+++ b/.claude/scripts/retrospection-config.json
@@ -1,0 +1,13 @@
+{
+  "resetDay": "Monday",
+  "resetHourUTC": 0,
+  "windowHours": 2,
+  "maxBudgetUsd": 5,
+  "tasks": [
+    "Fix any failing unit tests or type errors",
+    "Remove dead code and unused imports",
+    "Audit dependencies for updates",
+    "Improve test coverage for uncovered domain functions",
+    "Refactor overly complex functions"
+  ]
+}

--- a/.github/RUNNER_SETUP.md
+++ b/.github/RUNNER_SETUP.md
@@ -79,6 +79,41 @@ Configuration via environment variables in the workflow:
 
 The workflow timeout is set to 360 minutes (6 hours) to accommodate quota waits. GitHub Actions enforces a hard limit of 6 hours per job.
 
+## Pre-reset retrospection
+
+The script `.claude/scripts/pre-reset-retrospection.sh` runs quality-focused retrospection before the weekly token quota resets. It uses remaining quota for maintenance tasks (fix type errors, remove dead code, improve tests, audit dependencies).
+
+### How it works
+
+1. Checks if we're within the configured time window before quota reset (default: 2 hours)
+2. Checks if the runner is idle (no other Claude sessions running)
+3. Creates a branch, runs Claude with `--max-budget-usd` cap
+4. Creates a PR with any improvements
+
+### Configuration
+
+Edit `.claude/scripts/retrospection-config.json`:
+- `resetDay` — day of week quota resets (e.g. `"Monday"`)
+- `resetHourUTC` — hour (0-23) in UTC
+- `windowHours` — hours before reset to start (default: 2)
+- `maxBudgetUsd` — spending cap per session (default: 5)
+- `tasks` — prioritized list of retrospection tasks
+
+### Cron setup
+
+```bash
+# Run every 15 minutes — the script self-gates on the time window
+(crontab -l 2>/dev/null; echo "*/15 * * * * cd /home/bahm/Projects/spaced-learning && .claude/scripts/pre-reset-retrospection.sh >> /tmp/pre-reset-retrospection.log 2>&1") | crontab -
+```
+
+### Manual run
+
+```bash
+npm run retrospection:dry    # See what would happen
+npm run retrospection:force  # Run now, skip time-window check
+npm run retrospection        # Normal run (checks time window)
+```
+
 ## Stopping the runner
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -13,7 +13,10 @@
     "test:coverage": "vitest run --coverage",
     "test:e2e": "playwright test",
     "lint": "eslint src",
-    "memory:sync": "bash .claude/scripts/post-session.sh"
+    "memory:sync": "bash .claude/scripts/post-session.sh",
+    "retrospection": "bash .claude/scripts/pre-reset-retrospection.sh",
+    "retrospection:dry": "bash .claude/scripts/pre-reset-retrospection.sh --dry-run",
+    "retrospection:force": "bash .claude/scripts/pre-reset-retrospection.sh --force"
   },
   "repository": {
     "type": "git",

--- a/tests/unit/claudeRules.test.ts
+++ b/tests/unit/claudeRules.test.ts
@@ -85,6 +85,58 @@ describe('quota-retry wrapper script', () => {
   })
 })
 
+describe('pre-reset retrospection script', () => {
+  const RETRO_SCRIPT_PATH = join(__dirname, '../../.claude/scripts/pre-reset-retrospection.sh')
+  const RETRO_CONFIG_PATH = join(__dirname, '../../.claude/scripts/retrospection-config.json')
+
+  it('pre-reset-retrospection.sh exists', () => {
+    expect(existsSync(RETRO_SCRIPT_PATH)).toBe(true)
+  })
+
+  it('is executable (has shebang)', () => {
+    const content = readFileSync(RETRO_SCRIPT_PATH, 'utf-8')
+    expect(content.startsWith('#!/')).toBe(true)
+  })
+
+  it('checks if runner is idle before starting', () => {
+    const content = readFileSync(RETRO_SCRIPT_PATH, 'utf-8')
+    expect(content).toMatch(/idle|busy|lock|running/i)
+  })
+
+  it('calculates time window relative to quota reset', () => {
+    const content = readFileSync(RETRO_SCRIPT_PATH, 'utf-8')
+    expect(content).toMatch(/reset.*day|RESET_DAY|reset_day/i)
+    expect(content).toMatch(/window|WINDOW|hours.*before/i)
+  })
+
+  it('uses --max-budget-usd as spending cap', () => {
+    const content = readFileSync(RETRO_SCRIPT_PATH, 'utf-8')
+    expect(content).toMatch(/max-budget-usd|MAX_BUDGET/)
+  })
+
+  it('creates a branch and PR for retrospection changes', () => {
+    const content = readFileSync(RETRO_SCRIPT_PATH, 'utf-8')
+    expect(content).toMatch(/git checkout -b|branch/)
+    expect(content).toMatch(/gh pr create|pr create/)
+  })
+
+  it('retrospection-config.json exists and has required fields', () => {
+    expect(existsSync(RETRO_CONFIG_PATH)).toBe(true)
+    const config = JSON.parse(readFileSync(RETRO_CONFIG_PATH, 'utf-8'))
+    expect(config).toHaveProperty('resetDay')
+    expect(config).toHaveProperty('resetHourUTC')
+    expect(config).toHaveProperty('windowHours')
+    expect(config).toHaveProperty('maxBudgetUsd')
+  })
+
+  it('config has sensible defaults', () => {
+    const config = JSON.parse(readFileSync(RETRO_CONFIG_PATH, 'utf-8'))
+    expect(config.windowHours).toBeGreaterThanOrEqual(1)
+    expect(config.windowHours).toBeLessThanOrEqual(6)
+    expect(config.maxBudgetUsd).toBeGreaterThan(0)
+  })
+})
+
 describe('implement-from-issue workflow uses quota retry', () => {
   const workflowContent = readFileSync(WORKFLOW_PATH, 'utf-8')
 


### PR DESCRIPTION
## Summary
- Adds `pre-reset-retrospection.sh` script that runs quality-focused self-improvement (fix type errors, remove dead code, audit dependencies, improve tests) in the 2-hour window before the weekly token quota resets
- Uses time-based heuristics since there's no quota API — configurable via `retrospection-config.json` (reset day/hour, window size, budget cap)
- Checks runner is idle (lock file + process check) before starting; creates a branch and PR with improvements
- Adds npm scripts: `retrospection`, `retrospection:dry`, `retrospection:force`
- Includes cron setup instructions in RUNNER_SETUP.md

## Test plan
- [x] Unit tests pass (`npx vitest run tests/unit` — 53 tests including 8 new)
- [x] E2E tests pass (`npx playwright test` — 32 tests)
- [x] Type-check clean (`npx tsc --noEmit`)

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)