### PR TITLE
fix: prevent duplicate PRs when issue scope is updated

### DIFF
--- a/.claude/skills/implement-issue/SKILL.md
+++ b/.claude/skills/implement-issue/SKILL.md
@@ -112,6 +112,16 @@ gh pr list --state all --head $(git branch --show-current)
 ```
 If status is MERGED, the branch is stale — create a new branch from main and start a new PR.
 
+**Close existing open PRs for the same issue** — when triggered from a GitHub Issue, check for any existing open PRs that reference `Closes #<N>`. If found, close them with a comment explaining they are superseded, before creating the new PR:
+```bash
+# Find and close existing open PRs for this issue
+EXISTING_PRS=$(gh pr list --state open --search "Closes #<issue-number>" --json number --jq '.[].number')
+for PR_NUM in $EXISTING_PRS; do
+  gh pr close "$PR_NUM" --comment "Superseded by a new PR for issue #<issue-number> (scope was updated)."
+done
+```
+This prevents duplicate PRs when an issue's scope is updated and the workflow re-runs.
+
 When triggered from a GitHub Issue (i.e. an issue number was given in step 1), include `Closes #<N>` in the PR body so GitHub auto-closes the issue on merge.
 
 ```bash

--- a/.github/workflows/implement-from-issue.yml
+++ b/.github/workflows/implement-from-issue.yml
@@ -17,7 +17,7 @@ on:
 permissions:
   issues: write
   contents: read
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   implement:
@@ -50,6 +50,20 @@ jobs:
               repo: context.repo.repo,
               body: '🤖 **Claude Code** is starting work on this issue. A PR will be created when done.\n\nIf the token quota is reached, the runner will automatically wait for quota reset and resume.'
             })
+
+      - name: Close existing open PRs for this issue
+        working-directory: /home/bahm/Projects/spaced-learning
+        run: |
+          export NVM_DIR="${HOME}/.nvm"
+          source "${NVM_DIR}/nvm.sh"
+          # Find any existing open PRs that reference this issue
+          EXISTING_PRS=$(gh pr list --repo "${{ github.repository }}" --state open --search "Closes #${{ github.event.issue.number }}" --json number --jq '.[].number')
+          for PR_NUM in $EXISTING_PRS; do
+            echo "Closing superseded PR #$PR_NUM"
+            gh pr close "$PR_NUM" --repo "${{ github.repository }}" --comment "Superseded — re-running implementation for issue #${{ github.event.issue.number }} (scope was updated)."
+          done
+        env:
+          GH_TOKEN: ${{ github.token }}
 
       - name: Run implement-issue via quota-retry-wrapper
         working-directory: /home/bahm/Projects/spaced-learning

--- a/tests/unit/claudeRules.test.ts
+++ b/tests/unit/claudeRules.test.ts
@@ -85,6 +85,32 @@ describe('quota-retry wrapper script', () => {
   })
 })
 
+describe('implement-issue skill prevents duplicate PRs', () => {
+  const skillContent = readFileSync(SKILL_PATH, 'utf-8')
+
+  it('step 8 instructs to check for existing open PRs for the same issue', () => {
+    const step8Match = skillContent.match(/### 8\. Create PR([\s\S]*?)(?=### 9\.|$)/)
+    expect(step8Match, 'step 8 must exist').not.toBeNull()
+    const step8Content = step8Match![1]!
+    expect(step8Content).toMatch(/gh pr list.*Closes #|existing.*open.*PR|duplicate.*PR/i)
+  })
+
+  it('step 8 instructs to close superseded PRs before creating a new one', () => {
+    const step8Match = skillContent.match(/### 8\. Create PR([\s\S]*?)(?=### 9\.|$)/)
+    expect(step8Match, 'step 8 must exist').not.toBeNull()
+    const step8Content = step8Match![1]!
+    expect(step8Content).toMatch(/gh pr close|close.*superseded|close.*existing/i)
+  })
+})
+
+describe('implement-from-issue workflow prevents duplicate PRs', () => {
+  const workflowContent = readFileSync(WORKFLOW_PATH, 'utf-8')
+
+  it('has a step to close existing PRs for the same issue before running Claude', () => {
+    expect(workflowContent).toMatch(/close.*existing.*PR|Close existing PR|supersed/i)
+  })
+})
+
 describe('implement-from-issue workflow uses quota retry', () => {
   const workflowContent = readFileSync(WORKFLOW_PATH, 'utf-8')
 


### PR DESCRIPTION
## Summary
- Adds duplicate PR detection to SKILL.md step 8: before creating a new PR, find and close any existing open PRs for the same issue
- Adds a "Close existing open PRs" step to the GitHub Actions workflow that runs before Claude, so re-triggered workflows clean up prior PRs automatically
- Upgrades `pull-requests` permission from `read` to `write` to allow closing PRs
- Adds 3 unit tests enforcing the duplicate PR prevention instructions exist

## Test plan
- [x] Unit tests pass (`npx vitest run tests/unit`) — 48 tests
- [x] E2E tests pass (`npx playwright test`) — 32 tests
- [x] Type-check clean (`npx tsc --noEmit`)

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)