### PR TITLE
feat: pre-reset retrospection for idle quota utilization

### DIFF
--- a/.claude/scripts/pre-reset-retrospection.sh
+++ b/.claude/scripts/pre-reset-retrospection.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+# pre-reset-retrospection.sh — Run quality-focused retrospection before weekly quota reset.
+#
+# Designed for cron (every 15 minutes). Self-gates:
+#   1. Only runs within `windowHours` before the configured quota reset time
+#   2. Only runs if the runner is idle (no active claude processes, no lock file)
+#
+# Usage:
+#   ./pre-reset-retrospection.sh              # normal (cron) mode
+#   ./pre-reset-retrospection.sh --dry-run    # show what would happen, don't execute
+#   ./pre-reset-retrospection.sh --force      # skip time-window check, run immediately
+#
+# Configuration: retrospection-config.json (same directory)
+#   resetDay      — day of week when quota resets (e.g. "Monday")
+#   resetHourUTC  — UTC hour (0-23) of reset
+#   windowHours   — hours before reset to start retrospection
+#   maxBudgetUsd  — spending cap per session
+#   tasks         — prioritized list of improvement tasks
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+CONFIG_FILE="$SCRIPT_DIR/retrospection-config.json"
+LOCK_FILE="/tmp/pre-reset-retrospection.lock"
+LOG_PREFIX="[retrospection]"
+
+# --- Flags ---
+DRY_RUN=false
+FORCE=false
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=true ;;
+    --force)   FORCE=true ;;
+    *)         echo "$LOG_PREFIX Unknown flag: $arg" >&2; exit 1 ;;
+  esac
+done
+
+log() { echo "$LOG_PREFIX $*"; }
+
+# --- Load config ---
+if [ ! -f "$CONFIG_FILE" ]; then
+  log "ERROR: Config file not found: $CONFIG_FILE"
+  exit 1
+fi
+
+RESET_DAY=$(jq -r '.resetDay' "$CONFIG_FILE")
+RESET_HOUR_UTC=$(jq -r '.resetHourUTC' "$CONFIG_FILE")
+WINDOW_HOURS=$(jq -r '.windowHours' "$CONFIG_FILE")
+MAX_BUDGET_USD=$(jq -r '.maxBudgetUsd' "$CONFIG_FILE")
+TASKS=$(jq -r '.tasks | join("\n- ")' "$CONFIG_FILE")
+
+# --- Time window check ---
+# Calculate next reset time and check if we're within the window
+check_time_window() {
+  local now_epoch reset_epoch window_start_epoch
+
+  now_epoch=$(date +%s)
+
+  # Find the next occurrence of resetDay at resetHourUTC
+  # Start from today, look forward up to 7 days
+  for days_ahead in $(seq 0 7); do
+    local candidate
+    candidate=$(date -u -d "+${days_ahead} days" +%A)
+    if [ "$candidate" = "$RESET_DAY" ]; then
+      reset_epoch=$(date -u -d "+${days_ahead} days ${RESET_HOUR_UTC}:00:00" +%s)
+      # If the reset time is in the past today, skip to next week
+      if [ "$reset_epoch" -le "$now_epoch" ] && [ "$days_ahead" -eq 0 ]; then
+        continue
+      fi
+      break
+    fi
+  done
+
+  if [ -z "${reset_epoch:-}" ]; then
+    log "ERROR: Could not calculate next reset time for $RESET_DAY"
+    return 1
+  fi
+
+  window_start_epoch=$(( reset_epoch - WINDOW_HOURS * 3600 ))
+
+  if [ "$now_epoch" -ge "$window_start_epoch" ] && [ "$now_epoch" -lt "$reset_epoch" ]; then
+    local hours_left=$(( (reset_epoch - now_epoch) / 3600 ))
+    log "Within window: ~${hours_left}h until reset on $RESET_DAY at ${RESET_HOUR_UTC}:00 UTC"
+    return 0
+  else
+    local next_window
+    next_window=$(date -d "@$window_start_epoch" '+%Y-%m-%d %H:%M %Z')
+    log "Outside window. Next window opens: $next_window"
+    return 1
+  fi
+}
+
+# --- Idle check ---
+check_idle() {
+  # Check for stale lock file (older than 2 hours = probably crashed)
+  if [ -f "$LOCK_FILE" ]; then
+    local lock_age
+    lock_age=$(( $(date +%s) - $(stat -c %Y "$LOCK_FILE") ))
+    if [ "$lock_age" -gt 7200 ]; then
+      log "Removing stale lock file (age: ${lock_age}s)"
+      rm -f "$LOCK_FILE"
+    else
+      log "Lock file exists (age: ${lock_age}s). Another session is running."
+      return 1
+    fi
+  fi
+
+  # Check for active claude CLI processes
+  if pgrep -f 'claude' > /dev/null 2>&1; then
+    log "Active claude process detected. Runner is busy."
+    return 1
+  fi
+
+  log "Runner is idle."
+  return 0
+}
+
+# --- Main ---
+log "Starting (dry_run=$DRY_RUN, force=$FORCE)"
+
+# Time window gate (skip if --force)
+if [ "$FORCE" = false ]; then
+  if ! check_time_window; then
+    log "Not in time window. Exiting."
+    exit 0
+  fi
+fi
+
+# Idle gate
+if ! check_idle; then
+  log "Runner is busy. Exiting."
+  exit 0
+fi
+
+if [ "$DRY_RUN" = true ]; then
+  log "DRY RUN — would run retrospection with:"
+  log "  Budget: \$${MAX_BUDGET_USD}"
+  log "  Tasks:"
+  log "  - $TASKS"
+  log "  Project: $PROJECT_DIR"
+  exit 0
+fi
+
+# --- Acquire lock ---
+trap 'rm -f "$LOCK_FILE"' EXIT
+echo $$ > "$LOCK_FILE"
+
+# --- Set up git branch ---
+cd "$PROJECT_DIR"
+
+# Source nvm
+export NVM_DIR="${HOME}/.nvm"
+# shellcheck source=/dev/null
+source "${NVM_DIR}/nvm.sh"
+
+BRANCH_NAME="chore/pre-reset-retrospection-$(date +%Y%m%d-%H%M)"
+
+git checkout main
+git pull
+git checkout -b "$BRANCH_NAME"
+
+# --- Run Claude ---
+log "Running claude with --max-budget-usd $MAX_BUDGET_USD"
+
+PROMPT="You are running in a pre-quota-reset retrospection window. Focus on quality improvements.
+
+Tasks (in priority order):
+- $TASKS
+
+Rules:
+- Work in $PROJECT_DIR
+- Run tests after changes: npx vitest run tests/unit && npx tsc --noEmit
+- Only commit changes that pass all checks
+- Keep changes focused and reviewable
+- Do NOT create new features — focus on quality, tests, and cleanup"
+
+claude --dangerously-skip-permissions \
+  --max-budget-usd "$MAX_BUDGET_USD" \
+  -p "$PROMPT" || true
+
+# --- Check for changes and create PR ---
+if git diff --quiet && git diff --cached --quiet; then
+  log "No changes made. Cleaning up branch."
+  git checkout main
+  git branch -D "$BRANCH_NAME"
+  exit 0
+fi
+
+log "Changes detected. Committing and creating PR."
+
+git add -A
+git commit -m "$(cat <<'EOF'
+chore: pre-reset retrospection improvements
+
+Automated quality improvements run during the pre-quota-reset window.
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+EOF
+)"
+
+git push -u origin "$BRANCH_NAME"
+
+# Unset GH_TOKEN to use personal gh auth (avoids github-actions[bot] token issues)
+unset GH_TOKEN 2>/dev/null || true
+
+gh pr create \
+  --title "chore: pre-reset retrospection $(date +%Y-%m-%d)" \
+  --body "$(cat <<'EOF'
+## Summary
+- Automated quality improvements from pre-quota-reset retrospection window
+- Tasks: fix tests, remove dead code, improve coverage, refactor
+
+## Test plan
+- [ ] Unit tests pass
+- [ ] Type-check clean
+- [ ] Changes are focused and reviewable
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code) (pre-reset retrospection)
+EOF
+)"
+
+log "Done. PR created on branch $BRANCH_NAME."

--- a/.claude/scripts/retrospection-config.json
+++ b/.claude/scripts/retrospection-config.json
@@ -1,0 +1,13 @@
+{
+  "resetDay": "Monday",
+  "resetHourUTC": 0,
+  "windowHours": 2,
+  "maxBudgetUsd": 5,
+  "tasks": [
+    "Fix any failing unit tests or type errors",
+    "Remove dead code and unused imports",
+    "Audit dependencies for updates",
+    "Improve test coverage for uncovered domain functions",
+    "Refactor overly complex functions"
+  ]
+}

--- a/.github/RUNNER_SETUP.md
+++ b/.github/RUNNER_SETUP.md
@@ -79,6 +79,40 @@ Configuration via environment variables in the workflow:
 
 The workflow timeout is set to 360 minutes (6 hours) to accommodate quota waits. GitHub Actions enforces a hard limit of 6 hours per job.
 
+## Pre-reset retrospection
+
+Before the weekly quota resets, idle quota can be used for automated quality improvements (dead code removal, test coverage, refactoring). The script `.claude/scripts/pre-reset-retrospection.sh` self-gates on both a time window and runner idleness.
+
+### Configuration
+
+Edit `.claude/scripts/retrospection-config.json`:
+
+| Field | Description | Default |
+|---|---|---|
+| `resetDay` | Day of week quota resets | `"Monday"` |
+| `resetHourUTC` | UTC hour of reset (0-23) | `0` |
+| `windowHours` | Hours before reset to start | `2` |
+| `maxBudgetUsd` | Spending cap per session | `5` |
+| `tasks` | Prioritized task list | See file |
+
+### Cron setup
+
+Run every 15 minutes — the script self-gates so it only acts within the window:
+
+```bash
+crontab -e
+# Add:
+*/15 * * * * cd /home/bahm/Projects/spaced-learning && .claude/scripts/pre-reset-retrospection.sh >> /tmp/pre-reset-retrospection.log 2>&1
+```
+
+### Manual usage
+
+```bash
+npm run retrospection:dry    # preview what would happen
+npm run retrospection:force  # skip time-window check, run now
+npm run retrospection        # normal mode (respects time window)
+```
+
 ## Stopping the runner
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -13,7 +13,10 @@
     "test:coverage": "vitest run --coverage",
     "test:e2e": "playwright test",
     "lint": "eslint src",
-    "memory:sync": "bash .claude/scripts/post-session.sh"
+    "memory:sync": "bash .claude/scripts/post-session.sh",
+    "retrospection": "bash .claude/scripts/pre-reset-retrospection.sh",
+    "retrospection:dry": "bash .claude/scripts/pre-reset-retrospection.sh --dry-run",
+    "retrospection:force": "bash .claude/scripts/pre-reset-retrospection.sh --force"
   },
   "repository": {
     "type": "git",

--- a/tests/unit/claudeRules.test.ts
+++ b/tests/unit/claudeRules.test.ts
@@ -1,11 +1,13 @@
 import { describe, it, expect } from 'vitest'
-import { readFileSync, readdirSync, existsSync } from 'fs'
+import { readFileSync, readdirSync, existsSync, statSync } from 'fs'
 import { join } from 'path'
 
 const RULES_DIR = join(__dirname, '../../.claude/rules')
 const SKILL_PATH = join(__dirname, '../../.claude/skills/implement-issue/SKILL.md')
 const WRAPPER_SCRIPT_PATH = join(__dirname, '../../.claude/scripts/quota-retry-wrapper.sh')
 const WORKFLOW_PATH = join(__dirname, '../../.github/workflows/implement-from-issue.yml')
+const RETROSPECTION_SCRIPT_PATH = join(__dirname, '../../.claude/scripts/pre-reset-retrospection.sh')
+const RETROSPECTION_CONFIG_PATH = join(__dirname, '../../.claude/scripts/retrospection-config.json')
 
 describe('.claude/rules/ structure', () => {
   it('rules directory exists', () => {
@@ -127,5 +129,93 @@ describe('implement-from-issue workflow uses quota retry', () => {
 
   it('posts a comment when waiting for quota reset', () => {
     expect(workflowContent).toMatch(/quota.*reset|waiting.*quota/i)
+  })
+})
+
+describe('pre-reset retrospection script', () => {
+  it('pre-reset-retrospection.sh exists', () => {
+    expect(existsSync(RETROSPECTION_SCRIPT_PATH)).toBe(true)
+  })
+
+  it('is executable (has shebang)', () => {
+    const content = readFileSync(RETROSPECTION_SCRIPT_PATH, 'utf-8')
+    expect(content.startsWith('#!/')).toBe(true)
+  })
+
+  it('has executable permissions', () => {
+    const stat = statSync(RETROSPECTION_SCRIPT_PATH)
+    const isExecutable = (stat.mode & 0o111) !== 0
+    expect(isExecutable).toBe(true)
+  })
+
+  it('checks if runner is idle before starting', () => {
+    const content = readFileSync(RETROSPECTION_SCRIPT_PATH, 'utf-8')
+    expect(content).toMatch(/claude.*process|pgrep|pidof|lock/i)
+  })
+
+  it('calculates time window relative to quota reset', () => {
+    const content = readFileSync(RETROSPECTION_SCRIPT_PATH, 'utf-8')
+    expect(content).toMatch(/windowHours|window_hours|WINDOW/i)
+    expect(content).toMatch(/resetDay|reset_day|RESET_DAY/i)
+  })
+
+  it('uses --max-budget-usd as spending cap', () => {
+    const content = readFileSync(RETROSPECTION_SCRIPT_PATH, 'utf-8')
+    expect(content).toMatch(/max-budget-usd/)
+  })
+
+  it('creates a branch for retrospection changes', () => {
+    const content = readFileSync(RETROSPECTION_SCRIPT_PATH, 'utf-8')
+    expect(content).toMatch(/git checkout -b|git switch -c/)
+  })
+
+  it('creates a PR for retrospection changes', () => {
+    const content = readFileSync(RETROSPECTION_SCRIPT_PATH, 'utf-8')
+    expect(content).toMatch(/gh pr create/)
+  })
+
+  it('supports --dry-run and --force flags', () => {
+    const content = readFileSync(RETROSPECTION_SCRIPT_PATH, 'utf-8')
+    expect(content).toMatch(/dry.run/i)
+    expect(content).toMatch(/force/i)
+  })
+})
+
+describe('retrospection-config.json', () => {
+  it('exists with required fields', () => {
+    expect(existsSync(RETROSPECTION_CONFIG_PATH)).toBe(true)
+    const config = JSON.parse(readFileSync(RETROSPECTION_CONFIG_PATH, 'utf-8'))
+    expect(config).toHaveProperty('resetDay')
+    expect(config).toHaveProperty('resetHourUTC')
+    expect(config).toHaveProperty('windowHours')
+    expect(config).toHaveProperty('maxBudgetUsd')
+    expect(config).toHaveProperty('tasks')
+  })
+
+  it('has sensible defaults', () => {
+    const config = JSON.parse(readFileSync(RETROSPECTION_CONFIG_PATH, 'utf-8'))
+    expect(typeof config.resetDay).toBe('string')
+    expect(config.resetHourUTC).toBeGreaterThanOrEqual(0)
+    expect(config.resetHourUTC).toBeLessThanOrEqual(23)
+    expect(config.windowHours).toBeGreaterThan(0)
+    expect(config.maxBudgetUsd).toBeGreaterThan(0)
+    expect(Array.isArray(config.tasks)).toBe(true)
+    expect(config.tasks.length).toBeGreaterThan(0)
+  })
+})
+
+describe('package.json has retrospection npm scripts', () => {
+  const pkg = JSON.parse(readFileSync(join(__dirname, '../../package.json'), 'utf-8'))
+
+  it('has retrospection script', () => {
+    expect(pkg.scripts.retrospection).toMatch(/pre-reset-retrospection/)
+  })
+
+  it('has retrospection:dry script', () => {
+    expect(pkg.scripts['retrospection:dry']).toMatch(/dry-run/)
+  })
+
+  it('has retrospection:force script', () => {
+    expect(pkg.scripts['retrospection:force']).toMatch(/force/)
   })
 })


### PR DESCRIPTION
## Summary
- Adds `pre-reset-retrospection.sh` — cron-driven script that uses idle quota for quality improvements (dead code removal, test coverage, refactoring) in the 2-hour window before weekly reset
- Configurable via `retrospection-config.json` (reset day/hour, window size, budget cap, task list)
- Self-gates on time window + runner idleness (lock file + process check)
- Supports `--dry-run` and `--force` flags; npm scripts: `retrospection`, `retrospection:dry`, `retrospection:force`
- 14 new unit tests verify script structure, config schema, and npm scripts

## Test plan
- [x] Unit tests pass (`npx vitest run tests/unit` — 62 pass)
- [x] E2E tests pass (`npx playwright test` — 32 pass)
- [x] Type-check clean (`npx tsc --noEmit`)

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)