### PR TITLE
fix: detect 'hit your limit' quota message from Claude CLI

### DIFF
--- a/.claude/scripts/quota-retry-wrapper.sh
+++ b/.claude/scripts/quota-retry-wrapper.sh
@@ -66,13 +66,20 @@ parse_reset_time() {
     return 0
   fi
 
+  # Try "resets <time> (<timezone>)" format (e.g. "resets 11pm (Asia/Saigon)")
+  reset_str=$(echo "$output" | grep -oiP '(?:reset(?:s)?)\s+\K\d{1,2}(?::\d{2})?\s*(?:am|pm)\s*(?:\([^)]+\))?' | head -1)
+  if [ -n "$reset_str" ]; then
+    echo "$reset_str"
+    return 0
+  fi
+
   return 1
 }
 
 # Detect if the output contains a quota/rate-limit error
 is_quota_error() {
   local output="$1"
-  echo "$output" | grep -qiP 'quota|rate.limit|token.limit|usage.limit|billing|credit|exceeded.*limit'
+  echo "$output" | grep -qiP 'quota|rate.limit|token.limit|usage.limit|billing|credit|exceeded.*limit|hit\s+(your\s+)?limit'
 }
 
 # Calculate seconds to wait until the parsed reset time
@@ -80,11 +87,32 @@ calculate_wait_secs() {
   local reset_str="$1"
   local reset_epoch now_epoch wait_secs
 
-  reset_epoch=$(date -d "$reset_str" +%s 2>/dev/null) || return 1
+  # Handle "11pm (Asia/Saigon)" format — extract timezone from parens
+  local tz_override=""
+  local paren_re='[(]([^)]+)[)]'
+  if [[ "$reset_str" =~ $paren_re ]]; then
+    tz_override="${BASH_REMATCH[1]}"
+    # Remove the parenthesized timezone from the time string
+    reset_str=$(echo "$reset_str" | sed 's/\s*([^)]*)//g' | xargs)
+    # Parse the time in the specified timezone
+    reset_epoch=$(TZ="$tz_override" date -d "today $reset_str" +%s 2>/dev/null) || \
+      reset_epoch=$(TZ="$tz_override" date -d "tomorrow $reset_str" +%s 2>/dev/null) || return 1
+  else
+    reset_epoch=$(date -d "$reset_str" +%s 2>/dev/null) || return 1
+  fi
+
   now_epoch=$(date +%s)
 
   if [ "$reset_epoch" -le "$now_epoch" ]; then
-    # Reset time is in the past — use default wait
+    # Reset time is in the past for today — try tomorrow
+    if [ -n "$tz_override" ]; then
+      reset_epoch=$(TZ="$tz_override" date -d "tomorrow $reset_str" +%s 2>/dev/null) || return 1
+    else
+      return 1
+    fi
+  fi
+
+  if [ "$reset_epoch" -le "$now_epoch" ]; then
     return 1
   fi
 

--- a/.claude/skills/implement-issue/SKILL.md
+++ b/.claude/skills/implement-issue/SKILL.md
@@ -24,7 +24,7 @@ description: >
 > **All 9 steps are mandatory on every PR** — including style-only, docs-only, and trivial fixes. The steps most tempting to skip on "simple" PRs (TDD in step 4, retrospection in step 9) are the ones where discipline pays off most.
 
 ### 1. Read the spec
-- If given an issue number: `gh issue view <N>` to read title + body
+- If given an issue number: `gh issue view <N> --json title,body,labels,comments` to read the full issue context including all comments. Comments often contain updated instructions, clarifications, or scope changes from the user — they are as important as the original body.
 - If given a description: treat that as the spec
 - Confirm understanding before writing any code
 

--- a/.github/workflows/implement-from-issue.yml
+++ b/.github/workflows/implement-from-issue.yml
@@ -65,17 +65,42 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
 
+      - name: Fetch issue context with comments
+        id: issue-context
+        working-directory: /home/bahm/Projects/spaced-learning
+        run: |
+          export NVM_DIR="${HOME}/.nvm"
+          source "${NVM_DIR}/nvm.sh"
+          # Fetch full issue context including comments so Claude has all instructions
+          ISSUE_CONTEXT=$(gh issue view ${{ github.event.issue.number }} \
+            --repo "${{ github.repository }}" \
+            --json title,body,comments \
+            --jq '{title: .title, body: .body, comments: [.comments[] | select(.authorAssociation == "OWNER" or .authorAssociation == "MEMBER" or .authorAssociation == "COLLABORATOR") | {author: .author.login, body: .body}]}')
+          # Write to a temp file to avoid shell escaping issues
+          echo "$ISSUE_CONTEXT" > /tmp/issue-context-${{ github.event.issue.number }}.json
+        env:
+          GH_TOKEN: ${{ github.token }}
+
       - name: Run implement-issue via quota-retry-wrapper
         working-directory: /home/bahm/Projects/spaced-learning
         run: |
           export NVM_DIR="${HOME}/.nvm"
           source "${NVM_DIR}/nvm.sh"
           unset GH_TOKEN
+          # Read issue context including comments
+          ISSUE_CONTEXT=$(cat /tmp/issue-context-${{ github.event.issue.number }}.json 2>/dev/null || echo "")
+          CONTEXT_PROMPT=""
+          if [ -n "$ISSUE_CONTEXT" ]; then
+            CONTEXT_PROMPT="
+
+Here is the full issue context including comments from authorized users (comments may contain updated instructions or scope changes — treat them as part of the spec):
+$ISSUE_CONTEXT"
+          fi
           .claude/scripts/quota-retry-wrapper.sh \
             "${{ github.event.issue.number }}" \
             "${{ github.repository }}" \
             --dangerously-skip-permissions -p \
-            "/implement-issue #${{ github.event.issue.number }}. You MUST complete the full workflow: write failing tests, implement, verify, commit, and open a PR. Do not stop at planning."
+            "/implement-issue #${{ github.event.issue.number }}. You MUST complete the full workflow: write failing tests, implement, verify, commit, and open a PR. Do not stop at planning.${CONTEXT_PROMPT}"
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           MAX_RETRIES: "2"

--- a/tests/unit/claudeRules.test.ts
+++ b/tests/unit/claudeRules.test.ts
@@ -85,6 +85,32 @@ describe('quota-retry wrapper script', () => {
     const content = readFileSync(WRAPPER_SCRIPT_PATH, 'utf-8')
     expect(content.startsWith('#!/')).toBe(true)
   })
+
+  it('is_quota_error matches "You\'ve hit your limit" message', () => {
+    const content = readFileSync(WRAPPER_SCRIPT_PATH, 'utf-8')
+    // Extract the is_quota_error grep pattern
+    const grepMatch = content.match(/is_quota_error\(\)\s*\{[\s\S]*?grep\s+-qiP\s+'([^']+)'/)
+    expect(grepMatch, 'is_quota_error must use grep -qiP with a pattern').not.toBeNull()
+    const pattern = grepMatch![1]!
+    // The actual Claude CLI message: "You've hit your limit · resets 11pm (Asia/Saigon)"
+    const regex = new RegExp(pattern, 'i')
+    expect(regex.test("You've hit your limit · resets 11pm (Asia/Saigon)")).toBe(true)
+  })
+
+  it('is_quota_error matches "hit your limit" without prefix', () => {
+    const content = readFileSync(WRAPPER_SCRIPT_PATH, 'utf-8')
+    const grepMatch = content.match(/is_quota_error\(\)\s*\{[\s\S]*?grep\s+-qiP\s+'([^']+)'/)
+    expect(grepMatch).not.toBeNull()
+    const pattern = grepMatch![1]!
+    const regex = new RegExp(pattern, 'i')
+    expect(regex.test("hit your limit")).toBe(true)
+  })
+
+  it('parse_reset_time handles "resets <time> (<timezone>)" format', () => {
+    const content = readFileSync(WRAPPER_SCRIPT_PATH, 'utf-8')
+    // The script must have a pattern that can extract time from "resets 11pm (Asia/Saigon)"
+    expect(content).toMatch(/resets?\s+\d|resets?\s+at|resets?\s+\S/i)
+  })
 })
 
 describe('implement-issue skill prevents duplicate PRs', () => {
@@ -110,6 +136,37 @@ describe('implement-from-issue workflow prevents duplicate PRs', () => {
 
   it('has a step to close existing PRs for the same issue before running Claude', () => {
     expect(workflowContent).toMatch(/close.*existing.*PR|Close existing PR|supersed/i)
+  })
+})
+
+describe('implement-issue skill reads issue comments', () => {
+  const skillContent = readFileSync(SKILL_PATH, 'utf-8')
+
+  it('step 1 instructs to read issue comments, not just title and body', () => {
+    const step1Match = skillContent.match(/### 1\. Read the spec([\s\S]*?)(?=### 2\.)/)
+    expect(step1Match, 'step 1 must exist').not.toBeNull()
+    const step1Content = step1Match![1]!
+    expect(step1Content).toMatch(/comments/i)
+  })
+
+  it('uses gh issue view with --json that includes comments field', () => {
+    const step1Match = skillContent.match(/### 1\. Read the spec([\s\S]*?)(?=### 2\.)/)
+    expect(step1Match, 'step 1 must exist').not.toBeNull()
+    const step1Content = step1Match![1]!
+    expect(step1Content).toMatch(/--json.*comments|comments.*--json/i)
+  })
+})
+
+describe('implement-from-issue workflow passes issue comments to Claude', () => {
+  const workflowContent = readFileSync(WORKFLOW_PATH, 'utf-8')
+
+  it('fetches issue comments before running Claude', () => {
+    expect(workflowContent).toMatch(/gh issue view.*comments|issue.*comments/i)
+  })
+
+  it('passes issue context including comments to the Claude prompt', () => {
+    // The prompt or an env var should contain the issue comments
+    expect(workflowContent).toMatch(/ISSUE_CONTEXT|issue_context|comments/i)
   })
 })
 


### PR DESCRIPTION
## Summary
- Fixed quota-retry-wrapper failing to detect Claude CLI's actual quota error message (`"You've hit your limit · resets 11pm (Asia/Saigon)"`)
- Added `hit\s+(your\s+)?limit` pattern to `is_quota_error()` 
- Added `parse_reset_time()` support for `"resets <time> (<timezone>)"` format
- Updated `calculate_wait_secs()` to handle timezone in parentheses (e.g. `Asia/Saigon`) via `TZ` env var
- Workflow now fetches issue comments and passes them to Claude prompt (from prior branch work)

## Test plan
- [x] Unit tests pass (`npx vitest run tests/unit`) — 69 tests, 3 new tests for quota detection
- [x] E2E tests pass (`npx playwright test`) — 32 tests
- [x] Type-check clean (`npx tsc --noEmit`)
- [x] Integration-tested `is_quota_error` and `parse_reset_time` with actual CLI error message

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)