### PR TITLE
fix: broken workflow YAML and add CI validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,22 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Validate workflow YAML
+        run: |
+          pip install --quiet pyyaml
+          python3 -c "
+          import yaml, glob, sys
+          errors = 0
+          for f in glob.glob('.github/workflows/*.yml'):
+              try:
+                  yaml.safe_load(open(f))
+                  print(f'✓ {f}')
+              except yaml.YAMLError as e:
+                  print(f'✗ {f}: {e}', file=sys.stderr)
+                  errors += 1
+          sys.exit(errors)
+          "
+
       - name: Type check
         run: npx tsc --noEmit
 

--- a/.github/workflows/implement-from-issue.yml
+++ b/.github/workflows/implement-from-issue.yml
@@ -91,10 +91,7 @@ jobs:
           ISSUE_CONTEXT=$(cat /tmp/issue-context-${{ github.event.issue.number }}.json 2>/dev/null || echo "")
           CONTEXT_PROMPT=""
           if [ -n "$ISSUE_CONTEXT" ]; then
-            CONTEXT_PROMPT="
-
-Here is the full issue context including comments from authorized users (comments may contain updated instructions or scope changes — treat them as part of the spec):
-$ISSUE_CONTEXT"
+            CONTEXT_PROMPT=$(printf '\n\nHere is the full issue context including comments from authorized users (comments may contain updated instructions or scope changes — treat them as part of the spec):\n%s' "$ISSUE_CONTEXT")
           fi
           .claude/scripts/quota-retry-wrapper.sh \
             "${{ github.event.issue.number }}" \


### PR DESCRIPTION
## Summary
- Fix broken YAML in `implement-from-issue.yml` — a multiline string broke out of the YAML block indentation, causing all push-triggered runs to fail
- Add a YAML validation step to CI that lints all workflow files before the rest of the pipeline
- Enable branch protection on `main` requiring the `test` job to pass before merge

## Test plan
- [ ] CI passes with the new YAML validation step
- [ ] Verify branch protection is active on `main` (requires `test` status check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)