### PR TITLE
fix: handle multi-day quota reset times in retry wrapper

### DIFF
--- a/.claude/scripts/quota-retry-wrapper.sh
+++ b/.claude/scripts/quota-retry-wrapper.sh
@@ -66,7 +66,14 @@ parse_reset_time() {
     return 0
   fi
 
-  # Try "resets <time> (<timezone>)" format (e.g. "resets 11pm (Asia/Saigon)")
+  # Try "resets <month> <day>, <time> (<timezone>)" format (e.g. "resets Mar 17, 7am (Asia/Saigon)")
+  reset_str=$(echo "$output" | grep -oiP '(?:reset(?:s)?)\s+\K[A-Z][a-z]{2}\s+\d{1,2},?\s*\d{1,2}(?::\d{2})?\s*(?:am|pm)\s*(?:\([^)]+\))?' | head -1)
+  if [ -n "$reset_str" ]; then
+    echo "$reset_str"
+    return 0
+  fi
+
+  # Try "resets <time> (<timezone>)" format without date (e.g. "resets 11pm (Asia/Saigon)")
   reset_str=$(echo "$output" | grep -oiP '(?:reset(?:s)?)\s+\K\d{1,2}(?::\d{2})?\s*(?:am|pm)\s*(?:\([^)]+\))?' | head -1)
   if [ -n "$reset_str" ]; then
     echo "$reset_str"
@@ -87,16 +94,34 @@ calculate_wait_secs() {
   local reset_str="$1"
   local reset_epoch now_epoch wait_secs
 
-  # Handle "11pm (Asia/Saigon)" format — extract timezone from parens
+  # Handle "(Asia/Saigon)" timezone suffix — extract timezone from parens
   local tz_override=""
   local paren_re='[(]([^)]+)[)]'
   if [[ "$reset_str" =~ $paren_re ]]; then
     tz_override="${BASH_REMATCH[1]}"
     # Remove the parenthesized timezone from the time string
     reset_str=$(echo "$reset_str" | sed 's/\s*([^)]*)//g' | xargs)
-    # Parse the time in the specified timezone
-    reset_epoch=$(TZ="$tz_override" date -d "today $reset_str" +%s 2>/dev/null) || \
-      reset_epoch=$(TZ="$tz_override" date -d "tomorrow $reset_str" +%s 2>/dev/null) || return 1
+  fi
+
+  # Strip commas — GNU date doesn't accept "Mar 17, 7am" but does accept "Mar 17 7am"
+  reset_str=$(echo "$reset_str" | tr -d ',')
+
+  # Check if the string contains a month name (multi-day format like "Mar 17, 7am")
+  local has_date=false
+  local month_re='^(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s+'
+  if [[ "$reset_str" =~ $month_re ]]; then
+    has_date=true
+  fi
+
+  if [ -n "$tz_override" ]; then
+    if [ "$has_date" = true ]; then
+      # Date+time format: "Mar 17, 7am" — pass directly to date -d
+      reset_epoch=$(TZ="$tz_override" date -d "$reset_str" +%s 2>/dev/null) || return 1
+    else
+      # Time-only format: "11pm" — try today first, then tomorrow
+      reset_epoch=$(TZ="$tz_override" date -d "today $reset_str" +%s 2>/dev/null) || \
+        reset_epoch=$(TZ="$tz_override" date -d "tomorrow $reset_str" +%s 2>/dev/null) || return 1
+    fi
   else
     reset_epoch=$(date -d "$reset_str" +%s 2>/dev/null) || return 1
   fi
@@ -104,9 +129,12 @@ calculate_wait_secs() {
   now_epoch=$(date +%s)
 
   if [ "$reset_epoch" -le "$now_epoch" ]; then
-    # Reset time is in the past for today — try tomorrow
-    if [ -n "$tz_override" ]; then
+    if [ -n "$tz_override" ] && [ "$has_date" = false ]; then
+      # Time-only and in the past for today — try tomorrow
       reset_epoch=$(TZ="$tz_override" date -d "tomorrow $reset_str" +%s 2>/dev/null) || return 1
+    elif [ -n "$tz_override" ] && [ "$has_date" = true ]; then
+      # Date+time in the past — try next year (unlikely but handle gracefully)
+      reset_epoch=$(TZ="$tz_override" date -d "$reset_str next year" +%s 2>/dev/null) || return 1
     else
       return 1
     fi

--- a/tests/unit/claudeRules.test.ts
+++ b/tests/unit/claudeRules.test.ts
@@ -111,6 +111,89 @@ describe('quota-retry wrapper script', () => {
     // The script must have a pattern that can extract time from "resets 11pm (Asia/Saigon)"
     expect(content).toMatch(/resets?\s+\d|resets?\s+at|resets?\s+\S/i)
   })
+
+  it('parse_reset_time handles "resets <month> <day>, <time> (<timezone>)" format', () => {
+    const content = readFileSync(WRAPPER_SCRIPT_PATH, 'utf-8')
+    // Must have a grep pattern that matches "resets Mar 17, 7am (Asia/Saigon)" — date + time + tz
+    // This is the actual format observed in the failed GitHub Action run on 2026-03-14
+    expect(content).toMatch(/[A-Z][a-z]{2}\s+\d|month.*day|date.*time.*timezone/i)
+  })
+})
+
+describe('quota-retry-wrapper bash function integration', () => {
+  const execSync = require('child_process').execSync
+
+  // Helper: source the script functions and call one, returning stdout
+  const callBashFn = (fnCall: string): string => {
+    // Extract only function definitions using sed (between function_name() and closing })
+    // Then eval them and run the requested function call
+    const script = `
+eval "$(awk '/^[a-z_]+\\(\\)/{found=1} found{print} /^\\}$/ && found{found=0}' '${WRAPPER_SCRIPT_PATH}')"
+${fnCall}
+`
+    try {
+      return execSync(script, { shell: '/bin/bash', encoding: 'utf-8', timeout: 5000 }).trim()
+    } catch (e: unknown) {
+      return (e as { status?: number }).status?.toString() ?? 'error'
+    }
+  }
+
+  it('parse_reset_time extracts "Mar 17, 7am (Asia/Saigon)" from quota message', () => {
+    const output = callBashFn(
+      `parse_reset_time "You've hit your limit · resets Mar 17, 7am (Asia/Saigon)"`
+    )
+    // Should extract something parseable containing Mar 17 and the timezone
+    expect(output).toContain('Mar')
+    expect(output).toContain('17')
+    expect(output).toContain('Asia/Saigon')
+  })
+
+  it('parse_reset_time extracts "Mar 17, 7:00am (Asia/Saigon)" with minutes', () => {
+    const output = callBashFn(
+      `parse_reset_time "You've hit your limit · resets Mar 17, 7:00am (Asia/Saigon)"`
+    )
+    expect(output).toContain('Mar')
+    expect(output).toContain('17')
+  })
+
+  it('parse_reset_time still handles "11pm (Asia/Saigon)" without date', () => {
+    const output = callBashFn(
+      `parse_reset_time "You've hit your limit · resets 11pm (Asia/Saigon)"`
+    )
+    expect(output).toContain('11pm')
+    expect(output).toContain('Asia/Saigon')
+  })
+
+  it('calculate_wait_secs returns positive seconds for a future date+time+tz', () => {
+    // Use a date far in the future to ensure it's always ahead
+    const output = callBashFn(
+      `calculate_wait_secs "Dec 31, 11pm (UTC)"`
+    )
+    const secs = parseInt(output, 10)
+    expect(secs).toBeGreaterThan(60) // at least the 60s buffer
+  })
+
+  it('calculate_wait_secs handles multi-day waits (not just today/tomorrow)', () => {
+    // Create a date 3 days from now
+    const future = new Date()
+    future.setDate(future.getDate() + 3)
+    const monthNames = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
+    const monthStr = monthNames[future.getMonth()]
+    const dayStr = future.getDate().toString()
+    const resetStr = `${monthStr} ${dayStr}, 7am (UTC)`
+
+    const output = callBashFn(`calculate_wait_secs "${resetStr}"`)
+    const secs = parseInt(output, 10)
+    // Should be at least 2 days worth of seconds (172800) + 60s buffer
+    expect(secs).toBeGreaterThan(172800)
+  })
+
+  it('is_quota_error detects "You\'ve hit your limit · resets Mar 17, 7am" message', () => {
+    const output = callBashFn(
+      `is_quota_error "You've hit your limit · resets Mar 17, 7am (Asia/Saigon)" && echo "detected" || echo "missed"`
+    )
+    expect(output).toBe('detected')
+  })
 })
 
 describe('implement-issue skill prevents duplicate PRs', () => {


### PR DESCRIPTION
## Summary
- Fixed `parse_reset_time` to handle `"resets Mar 17, 7am (Asia/Saigon)"` format (date + time + timezone) — the actual format observed in the failed GitHub Action run on 2026-03-14
- Fixed `calculate_wait_secs` to parse month+day dates for multi-day waits instead of only "today"/"tomorrow" offsets
- Strip commas from reset strings since GNU `date` rejects `"Mar 17, 7am"` but accepts `"Mar 17 7am"`
- Added bash integration tests that actually invoke the script functions and verify output

## Test plan
- [x] Unit tests pass (`npx vitest run tests/unit`) — 76 tests, including 7 new integration tests
- [x] Type-check clean (`npx tsc --noEmit`)
- [x] Pre-commit hook passed

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)