### PR TITLE
fix: filter archived deck cards from review queue

### DIFF
--- a/src/db/reviewRepo.ts
+++ b/src/db/reviewRepo.ts
@@ -56,7 +56,10 @@ export const getDueCardsByDeck = async (deckId: string, now: Date = new Date()) 
 }
 
 export const getDueCards = async (now: Date = new Date()) => {
-  const allCards = await db.cards.toArray()
+  // Only include cards from active decks
+  const activeDecks = await db.decks.where('status').equals('active').toArray()
+  const activeDeckIds = new Set(activeDecks.map((d) => d.id))
+  const allCards = (await db.cards.toArray()).filter((c) => activeDeckIds.has(c.deckId))
   const schedules = await db.schedules.bulkGet(allCards.map((c) => c.id))
   // Cards with no schedule are new — always due. Cards with a schedule are due if due <= now.
   return allCards.filter((_, i) => {

--- a/tests/e2e/flashcards.spec.ts
+++ b/tests/e2e/flashcards.spec.ts
@@ -521,4 +521,29 @@ test.describe('Flashcard app', () => {
     await page.keyboard.press('3')
     await expect(page.getByText('All done!')).toBeVisible()
   })
+
+  test('archiving all decks shows "All done" on Review tab', async ({ page }) => {
+    // Create a deck with a card
+    await page.getByRole('button', { name: 'Decks' }).click()
+    await page.getByLabel('Deck name').fill('Ephemeral')
+    await page.getByRole('button', { name: 'Add Deck' }).click()
+    await page.locator('li').filter({ hasText: 'Ephemeral' }).getByRole('button', { name: 'Cards' }).click()
+    await page.getByLabel('Front').fill('Gone soon')
+    await page.getByLabel('Back').fill('Bye')
+    await page.getByRole('button', { name: 'Add Card' }).click()
+    await expect(page.getByRole('heading', { name: /Ephemeral.*1/ })).toBeVisible()
+
+    // Go back to decks list, then verify the card appears in global review
+    await page.getByRole('button', { name: '← Decks' }).click()
+    await page.getByRole('navigation').getByRole('button', { name: 'Review' }).click()
+    await expect(page.getByText('Gone soon')).toBeVisible()
+
+    // Archive the deck
+    await page.getByRole('navigation').getByRole('button', { name: 'Decks' }).click()
+    await page.locator('li').filter({ hasText: 'Ephemeral' }).getByRole('button', { name: /archive deck ephemeral/i }).click()
+
+    // Review tab should show "All done" — no cards from archived decks
+    await page.getByRole('navigation').getByRole('button', { name: 'Review' }).click()
+    await expect(page.getByText('All done!')).toBeVisible()
+  })
 })


### PR DESCRIPTION
## Summary
- `getDueCards()` now filters to only cards from active decks, fixing the bug where archived/uninstalled decks' cards still appeared in the Review tab
- Added E2E test that archives a deck and verifies "All done!" shows on Review tab

## Test plan
- [x] Unit tests pass (`npx vitest run tests/unit`) — 76 passing
- [x] E2E tests pass (`npx playwright test`) — 33 passing (including new test)
- [x] Type-check clean (`npx tsc --noEmit`)

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)