### PR TITLE
feat: auto-detect weekly quota reset via usage API

### DIFF
--- a/.claude/scripts/fetch-weekly-reset.sh
+++ b/.claude/scripts/fetch-weekly-reset.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# fetch-weekly-reset.sh — Fetch weekly quota reset time from the Anthropic OAuth usage API
+# and update retrospection-config.json with the correct resetDay and resetHourUTC.
+#
+# The Claude Code CLI stores OAuth credentials in ~/.claude/.credentials.json.
+# This script reads the accessToken, calls the usage API, and extracts the
+# seven_day.resets_at ISO 8601 timestamp to derive the next weekly reset day/hour.
+#
+# Usage: ./fetch-weekly-reset.sh [config_file]
+#   config_file — path to retrospection-config.json (default: same dir/retrospection-config.json)
+#
+# Exit codes:
+#   0 — success (config updated or already correct)
+#   1 — error (credentials missing, API failure, etc.)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONFIG_FILE="${1:-$SCRIPT_DIR/retrospection-config.json}"
+CREDENTIALS_FILE="${HOME}/.claude/.credentials.json"
+USAGE_API_URL="https://api.anthropic.com/api/oauth/usage"
+LOG_PREFIX="[fetch-weekly-reset]"
+
+log() { echo "$LOG_PREFIX $*"; }
+
+# --- Parse API response and update config ---
+# Extracted as a function so tests can call it with mock data.
+parse_and_update_config() {
+  local api_response="$1"
+  local config_file="$2"
+
+  # Extract seven_day.resets_at from the response
+  local resets_at
+  resets_at=$(echo "$api_response" | jq -r '.seven_day.resets_at // empty' 2>/dev/null)
+
+  if [ -z "$resets_at" ] || [ "$resets_at" = "null" ]; then
+    log "No seven_day reset time in API response. Config unchanged."
+    return 0
+  fi
+
+  # Parse ISO 8601 timestamp to derive day-of-week and UTC hour
+  # Example: "2026-03-24T00:00:01.220149+00:00" → Tuesday, 0
+  local reset_day reset_hour_utc
+  reset_day=$(date -u -d "$resets_at" +%A 2>/dev/null) || {
+    log "ERROR: Failed to parse resets_at timestamp: $resets_at"
+    return 1
+  }
+  reset_hour_utc=$(date -u -d "$resets_at" +%-H 2>/dev/null) || {
+    log "ERROR: Failed to extract hour from: $resets_at"
+    return 1
+  }
+
+  log "API reports weekly reset: $reset_day at ${reset_hour_utc}:00 UTC (from $resets_at)"
+
+  # Read current config for comparison
+  local current_day current_hour
+  current_day=$(jq -r '.resetDay' "$config_file")
+  current_hour=$(jq -r '.resetHourUTC' "$config_file")
+
+  if [ "$current_day" = "$reset_day" ] && [ "$current_hour" = "$reset_hour_utc" ]; then
+    log "Config already matches. No update needed."
+    return 0
+  fi
+
+  # Update config, preserving all other fields
+  log "Updating config: resetDay=$current_day→$reset_day, resetHourUTC=$current_hour→$reset_hour_utc"
+
+  local tmp_file
+  tmp_file=$(mktemp)
+  jq --arg day "$reset_day" --argjson hour "$reset_hour_utc" \
+    '.resetDay = $day | .resetHourUTC = $hour' "$config_file" > "$tmp_file"
+  mv "$tmp_file" "$config_file"
+
+  log "Config updated successfully."
+}
+
+# --- Main (skipped when sourced for testing) ---
+# If the script is being sourced (e.g., for testing), don't run main logic.
+# Callers can invoke parse_and_update_config directly.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+
+  # Validate credentials file
+  if [ ! -f "$CREDENTIALS_FILE" ]; then
+    log "ERROR: Claude credentials not found at $CREDENTIALS_FILE"
+    log "Run 'claude auth' to authenticate first."
+    exit 1
+  fi
+
+  # Extract OAuth access token
+  ACCESS_TOKEN=$(jq -r '.claudeAiOauth.accessToken // empty' "$CREDENTIALS_FILE" 2>/dev/null)
+  if [ -z "$ACCESS_TOKEN" ]; then
+    log "ERROR: No accessToken found in $CREDENTIALS_FILE"
+    exit 1
+  fi
+
+  # Validate config file
+  if [ ! -f "$CONFIG_FILE" ]; then
+    log "ERROR: Config file not found: $CONFIG_FILE"
+    exit 1
+  fi
+
+  # Call the usage API
+  log "Fetching usage data from Anthropic API..."
+  HTTP_RESPONSE=$(curl -s -w "\n%{http_code}" \
+    "$USAGE_API_URL" \
+    -H "Accept: application/json" \
+    -H "Authorization: Bearer $ACCESS_TOKEN" \
+    -H "anthropic-beta: oauth-2025-04-20" \
+    -H "User-Agent: claude-code/2.0.32" 2>/dev/null) || {
+    log "ERROR: curl failed to reach $USAGE_API_URL"
+    exit 1
+  }
+
+  # Split response body and HTTP status code
+  HTTP_BODY=$(echo "$HTTP_RESPONSE" | head -n -1)
+  HTTP_CODE=$(echo "$HTTP_RESPONSE" | tail -1)
+
+  if [ "$HTTP_CODE" != "200" ]; then
+    log "ERROR: API returned HTTP $HTTP_CODE"
+    log "Response: $HTTP_BODY"
+    exit 1
+  fi
+
+  # Validate JSON response
+  if ! echo "$HTTP_BODY" | jq . >/dev/null 2>&1; then
+    log "ERROR: Invalid JSON response from API"
+    exit 1
+  fi
+
+  parse_and_update_config "$HTTP_BODY" "$CONFIG_FILE"
+fi

--- a/.claude/scripts/pre-reset-retrospection.sh
+++ b/.claude/scripts/pre-reset-retrospection.sh
@@ -38,6 +38,15 @@ done
 
 log() { echo "$LOG_PREFIX $*"; }
 
+# --- Auto-update config from usage API ---
+# Fetch the latest weekly reset time before checking the time window.
+# This ensures resetDay/resetHourUTC stay accurate without manual config.
+if [ -x "$SCRIPT_DIR/fetch-weekly-reset.sh" ]; then
+  "$SCRIPT_DIR/fetch-weekly-reset.sh" "$SCRIPT_DIR/retrospection-config.json" || {
+    log "Warning: fetch-weekly-reset.sh failed. Using existing config."
+  }
+fi
+
 # --- Load config ---
 if [ ! -f "$CONFIG_FILE" ]; then
   log "ERROR: Config file not found: $CONFIG_FILE"

--- a/.claude/scripts/retrospection-config.json
+++ b/.claude/scripts/retrospection-config.json
@@ -1,5 +1,5 @@
 {
-  "resetDay": "Monday",
+  "resetDay": "Tuesday",
   "resetHourUTC": 0,
   "windowHours": 2,
   "maxBudgetUsd": 5,

--- a/tests/unit/claudeRules.test.ts
+++ b/tests/unit/claudeRules.test.ts
@@ -9,6 +9,7 @@ const WORKFLOW_PATH = join(__dirname, '../../.github/workflows/implement-from-is
 const RETROSPECTION_SCRIPT_PATH = join(__dirname, '../../.claude/scripts/pre-reset-retrospection.sh')
 const RETROSPECTION_CONFIG_PATH = join(__dirname, '../../.claude/scripts/retrospection-config.json')
 const UPDATE_RESET_CONFIG_PATH = join(__dirname, '../../.claude/scripts/update-reset-config.sh')
+const FETCH_WEEKLY_RESET_PATH = join(__dirname, '../../.claude/scripts/fetch-weekly-reset.sh')
 
 describe('.claude/rules/ structure', () => {
   it('rules directory exists', () => {
@@ -518,5 +519,134 @@ describe('package.json has retrospection npm scripts', () => {
 
   it('has retrospection:force script', () => {
     expect(pkg.scripts['retrospection:force']).toMatch(/force/)
+  })
+})
+
+describe('fetch-weekly-reset.sh usage API script', () => {
+  it('fetch-weekly-reset.sh exists', () => {
+    expect(existsSync(FETCH_WEEKLY_RESET_PATH)).toBe(true)
+  })
+
+  it('is executable (has shebang)', () => {
+    const content = readFileSync(FETCH_WEEKLY_RESET_PATH, 'utf-8')
+    expect(content.startsWith('#!/')).toBe(true)
+  })
+
+  it('has executable permissions', () => {
+    const stat = statSync(FETCH_WEEKLY_RESET_PATH)
+    const isExecutable = (stat.mode & 0o111) !== 0
+    expect(isExecutable).toBe(true)
+  })
+
+  it('reads OAuth token from Claude credentials file', () => {
+    const content = readFileSync(FETCH_WEEKLY_RESET_PATH, 'utf-8')
+    expect(content).toMatch(/credentials\.json|claudeAiOauth|accessToken/i)
+  })
+
+  it('calls the Anthropic OAuth usage API endpoint', () => {
+    const content = readFileSync(FETCH_WEEKLY_RESET_PATH, 'utf-8')
+    expect(content).toMatch(/api\.anthropic\.com.*oauth.*usage|oauth\/usage/)
+  })
+
+  it('extracts seven_day reset time from API response', () => {
+    const content = readFileSync(FETCH_WEEKLY_RESET_PATH, 'utf-8')
+    expect(content).toMatch(/seven_day|resets_at/)
+  })
+
+  it('updates retrospection-config.json with derived resetDay and resetHourUTC', () => {
+    const content = readFileSync(FETCH_WEEKLY_RESET_PATH, 'utf-8')
+    expect(content).toMatch(/resetDay/)
+    expect(content).toMatch(/resetHourUTC/)
+    expect(content).toMatch(/retrospection-config\.json/)
+  })
+
+  it('preserves other config fields when updating', () => {
+    const content = readFileSync(FETCH_WEEKLY_RESET_PATH, 'utf-8')
+    // Should use jq to update only specific fields
+    expect(content).toMatch(/jq/)
+  })
+
+  it('handles API errors gracefully without crashing', () => {
+    const content = readFileSync(FETCH_WEEKLY_RESET_PATH, 'utf-8')
+    // Should check HTTP status or response validity
+    expect(content).toMatch(/error|fail|invalid|null/i)
+  })
+})
+
+describe('fetch-weekly-reset.sh bash integration', () => {
+  const execSync = require('child_process').execSync
+  const { mkdtempSync, writeFileSync, unlinkSync, rmdirSync } = require('fs')
+  const { tmpdir } = require('os')
+
+  it('correctly parses ISO 8601 resets_at and updates config', () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), 'fetch-reset-test-'))
+    const configFile = join(tmpDir, 'retrospection-config.json')
+
+    writeFileSync(configFile, JSON.stringify({
+      resetDay: 'Friday',
+      resetHourUTC: 12,
+      windowHours: 2,
+      maxBudgetUsd: 5,
+      tasks: ['test task']
+    }))
+
+    // Call the parse_and_update function directly with a mock API response
+    // The script should have a function that takes JSON and config path
+    try {
+      const script = `
+source "${FETCH_WEEKLY_RESET_PATH}" --source-only 2>/dev/null || true
+# Extract functions using awk
+eval "$(awk '/^[a-z_]+\\(\\)/{found=1} found{print} /^\\}$/ && found{found=0}' '${FETCH_WEEKLY_RESET_PATH}')"
+MOCK_RESPONSE='{"seven_day":{"utilization":5.0,"resets_at":"2026-03-24T00:00:01.220149+00:00"}}'
+parse_and_update_config "$MOCK_RESPONSE" "${configFile}"
+`
+      execSync(script, { shell: '/bin/bash', encoding: 'utf-8', timeout: 5000 })
+      const updated = JSON.parse(readFileSync(configFile, 'utf-8'))
+      expect(updated.resetDay).toBe('Tuesday')
+      expect(updated.resetHourUTC).toBe(0)
+      // Preserved fields
+      expect(updated.windowHours).toBe(2)
+      expect(updated.maxBudgetUsd).toBe(5)
+      expect(updated.tasks).toEqual(['test task'])
+    } finally {
+      unlinkSync(configFile)
+      rmdirSync(tmpDir)
+    }
+  })
+
+  it('does not update config when API response has null seven_day', () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), 'fetch-reset-test-'))
+    const configFile = join(tmpDir, 'retrospection-config.json')
+
+    const originalConfig = {
+      resetDay: 'Friday',
+      resetHourUTC: 12,
+      windowHours: 2,
+      maxBudgetUsd: 5,
+      tasks: ['test task']
+    }
+    writeFileSync(configFile, JSON.stringify(originalConfig))
+
+    try {
+      const script = `
+eval "$(awk '/^[a-z_]+\\(\\)/{found=1} found{print} /^\\}$/ && found{found=0}' '${FETCH_WEEKLY_RESET_PATH}')"
+MOCK_RESPONSE='{"seven_day":null}'
+parse_and_update_config "$MOCK_RESPONSE" "${configFile}"
+`
+      execSync(script, { shell: '/bin/bash', encoding: 'utf-8', timeout: 5000 })
+      const updated = JSON.parse(readFileSync(configFile, 'utf-8'))
+      expect(updated.resetDay).toBe('Friday')
+      expect(updated.resetHourUTC).toBe(12)
+    } finally {
+      unlinkSync(configFile)
+      rmdirSync(tmpDir)
+    }
+  })
+})
+
+describe('pre-reset-retrospection.sh calls fetch-weekly-reset.sh', () => {
+  it('calls fetch-weekly-reset.sh to auto-update config before time window check', () => {
+    const content = readFileSync(RETROSPECTION_SCRIPT_PATH, 'utf-8')
+    expect(content).toMatch(/fetch-weekly-reset/)
   })
 })


### PR DESCRIPTION
## Summary
- Adds `fetch-weekly-reset.sh` — fetches the weekly quota reset time from `api.anthropic.com/api/oauth/usage` using the OAuth token stored in `~/.claude/.credentials.json`
- Extracts `seven_day.resets_at` (ISO 8601 timestamp) and derives `resetDay` + `resetHourUTC` for `retrospection-config.json`
- Integrates into `pre-reset-retrospection.sh` — auto-updates config before each time window check, so the cron job always uses accurate reset timing
- Replaces the previous calibration-log approach which only captured 5-hour resets (useless for weekly scheduling)

## How it works
1. `fetch-weekly-reset.sh` reads `~/.claude/.credentials.json` → extracts `claudeAiOauth.accessToken`
2. Calls `GET https://api.anthropic.com/api/oauth/usage` with OAuth bearer token
3. Parses `seven_day.resets_at` → derives day-of-week and UTC hour
4. Updates `retrospection-config.json` via `jq`, preserving all other fields
5. `pre-reset-retrospection.sh` calls this script on every cron invocation (before checking the time window)

## Manual steps
**None required** — if Claude Code is already authenticated (`~/.claude/.credentials.json` exists), the script works automatically. The cron job for `pre-reset-retrospection.sh` (already configured per `RUNNER_SETUP.md`) will start using the API on its next run.

To verify manually:
```bash
.claude/scripts/fetch-weekly-reset.sh
cat .claude/scripts/retrospection-config.json
```

## API details
- **Endpoint**: `GET https://api.anthropic.com/api/oauth/usage`
- **Auth**: `Authorization: Bearer <accessToken>` from `~/.claude/.credentials.json`
- **Required header**: `anthropic-beta: oauth-2025-04-20`
- **Response** (relevant fields):
  ```json
  {
    "seven_day": {
      "utilization": 5.0,
      "resets_at": "2026-03-24T00:00:01.220149+00:00"
    }
  }
  ```
- The `resets_at` timestamp is the exact next weekly reset in ISO 8601 format

## Test plan
- [x] 12 new unit tests covering script structure and bash integration
- [x] All 101 unit tests pass (`npx vitest run tests/unit`)
- [x] Type-check clean (`npx tsc --noEmit`)
- [x] End-to-end manual verification: script correctly updated config from Monday→Tuesday

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)