### PR TITLE
feat: integrate superpowers framework

### DIFF
--- a/.claude/rules/superpowers-integration.md
+++ b/.claude/rules/superpowers-integration.md
@@ -1,0 +1,50 @@
+---
+paths:
+  - .claude/**
+  - .github/**
+---
+
+# Superpowers Framework Integration
+
+The Superpowers plugin (obra/superpowers) is installed globally on the self-hosted runner. It provides structured development skills that complement the project's existing automation.
+
+## How superpowers fits with existing automation
+
+The `/implement-issue` skill remains the primary automated workflow for issue-driven development. Superpowers skills are available as complementary tools:
+
+| Superpowers skill | When to use | Relation to existing workflow |
+|---|---|---|
+| `/superpowers:brainstorming` | Complex features needing design exploration | Use before `/implement-issue` for ambiguous issues |
+| `/superpowers:spec` | Writing detailed specs from brainstorming output | Feeds into implement-issue step 1 (read the spec) |
+| `/superpowers:plan` | Breaking large specs into bite-sized tasks | Complements implement-issue step 5 (implement) |
+| `/superpowers:tdd` | Interactive TDD with strict RED-GREEN-REFACTOR gates | Implement-issue step 4-5 already enforce TDD |
+| `/superpowers:subagent` | Delegating parallel subtasks | Use for large changes spanning multiple layers |
+| `/superpowers:review` | Code review and finalization | Complements implement-issue step 9 (retrospection) |
+
+## Automated pipeline integration
+
+For fully automated runs (GitHub Actions `auto-implement` label):
+- The issue body serves as the spec — no interactive brainstorming needed
+- `/implement-issue` drives the full TDD workflow end-to-end
+- Superpowers TDD skill is NOT used in automated runs (would conflict with implement-issue's own TDD flow)
+
+For interactive sessions:
+- Use `/superpowers:brainstorming` for complex features before creating an issue
+- Use `/superpowers:plan` to break large issues into sub-issues
+- The implement-issue skill handles execution
+
+## Retrospection and continuous improvement
+
+Superpowers' review skill complements the project's existing continuous improvement infrastructure:
+- **Pre-reset retrospection** (`.claude/scripts/pre-reset-retrospection.sh`) — automated quality improvements before quota reset
+- **Implement-issue step 9** — mandatory retrospection after every PR
+- **Superpowers review** — additional structured review during interactive sessions
+
+The three mechanisms work at different scopes:
+1. Superpowers review → per-change quality (interactive)
+2. Implement-issue step 9 → per-PR lessons and best-practices audit (automated + interactive)
+3. Pre-reset retrospection → periodic codebase-wide improvements (automated)
+
+## Setup
+
+Run `.claude/scripts/setup-superpowers.sh` once on the self-hosted runner. The script is idempotent.

--- a/.claude/scripts/setup-superpowers.sh
+++ b/.claude/scripts/setup-superpowers.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# Setup script for the Superpowers framework (Claude Code plugin)
+# https://github.com/obra/superpowers
+#
+# Superpowers provides structured development skills: brainstorming,
+# spec writing, planning, TDD, subagent delegation, and review.
+# It complements the project's existing /implement-issue skill.
+#
+# This script is idempotent — safe to run multiple times.
+# Run once on the self-hosted runner after initial setup.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+echo "=== Superpowers Plugin Setup ==="
+
+# Check if Claude Code CLI is available
+if ! command -v claude &>/dev/null; then
+  echo "Error: 'claude' CLI not found in PATH."
+  echo "Install Claude Code first: https://docs.anthropic.com/en/docs/claude-code"
+  exit 1
+fi
+
+# Check if superpowers marketplace is already added
+if claude /plugin marketplace list 2>/dev/null | grep -q "superpowers-marketplace"; then
+  echo "✓ Superpowers marketplace already added — skipping."
+else
+  echo "Adding superpowers marketplace..."
+  claude /plugin marketplace add obra/superpowers-marketplace
+  echo "✓ Marketplace added."
+fi
+
+# Check if superpowers plugin is already installed
+if claude /plugin list 2>/dev/null | grep -q "superpowers"; then
+  echo "✓ Superpowers plugin already installed — skipping."
+else
+  echo "Installing superpowers plugin (global)..."
+  claude /plugin install superpowers@superpowers-marketplace --global
+  echo "✓ Superpowers installed globally."
+fi
+
+echo ""
+echo "=== Setup Complete ==="
+echo ""
+echo "Available superpowers skills:"
+echo "  /superpowers:brainstorming  — Socratic design exploration"
+echo "  /superpowers:spec           — Write a detailed spec from design"
+echo "  /superpowers:plan           — Break spec into bite-sized tasks"
+echo "  /superpowers:tdd            — RED-GREEN-REFACTOR with gates"
+echo "  /superpowers:subagent       — Delegate subtasks to child agents"
+echo "  /superpowers:review         — Code review and finalization"
+echo ""
+echo "Integration notes:"
+echo "  - /implement-issue remains the primary automated workflow"
+echo "  - Superpowers skills are available for interactive sessions"
+echo "  - See .claude/rules/superpowers-integration.md for details"

--- a/.github/RUNNER_SETUP.md
+++ b/.github/RUNNER_SETUP.md
@@ -45,6 +45,17 @@ The workflow passes this to `claude` so it can call the model.
 gh label create auto-implement --color 0075ca --description "Trigger Claude Code to implement this issue automatically"
 ```
 
+### 5. Install the Superpowers plugin
+
+The [Superpowers framework](https://github.com/obra/superpowers) provides structured development skills (brainstorming, planning, TDD, review) that complement the project's `/implement-issue` workflow.
+
+```bash
+cd /home/bahm/Projects/spaced-learning
+.claude/scripts/setup-superpowers.sh
+```
+
+The script is idempotent — safe to run multiple times. The workflow also runs it automatically before each issue implementation.
+
 ## Using it
 
 1. Create a GitHub Issue describing the feature or fix

--- a/.github/workflows/implement-from-issue.yml
+++ b/.github/workflows/implement-from-issue.yml
@@ -65,6 +65,14 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
 
+      - name: Ensure superpowers plugin is available
+        working-directory: /home/bahm/Projects/spaced-learning
+        run: |
+          export NVM_DIR="${HOME}/.nvm"
+          source "${NVM_DIR}/nvm.sh"
+          # Run idempotent setup — skips if already installed
+          .claude/scripts/setup-superpowers.sh || echo "Warning: superpowers setup failed (non-blocking)"
+
       - name: Fetch issue context with comments
         id: issue-context
         working-directory: /home/bahm/Projects/spaced-learning

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,10 @@ See `.claude/rules/e2e-testing.md` for Playwright-specific patterns and pitfalls
 
 When compacting, preserve: the nvm sourcing requirement, snake_case field names for ScheduleRecord, the architecture layering rules, and any in-progress file paths.
 
+## Superpowers plugin
+
+The [Superpowers framework](https://github.com/obra/superpowers) is installed globally. It provides `/superpowers:brainstorming`, `/superpowers:plan`, `/superpowers:tdd`, and other structured skills. See `.claude/rules/superpowers-integration.md` for how they complement `/implement-issue`.
+
 ## Workflow
 
 1. Create a GitHub Issue describing the feature/fix

--- a/tests/unit/claudeRules.test.ts
+++ b/tests/unit/claudeRules.test.ts
@@ -644,6 +644,76 @@ parse_and_update_config "$MOCK_RESPONSE" "${configFile}"
   })
 })
 
+describe('superpowers integration', () => {
+  const SETUP_SCRIPT_PATH = join(__dirname, '../../.claude/scripts/setup-superpowers.sh')
+  const SUPERPOWERS_RULES_PATH = join(__dirname, '../../.claude/rules/superpowers-integration.md')
+
+  it('setup-superpowers.sh exists', () => {
+    expect(existsSync(SETUP_SCRIPT_PATH)).toBe(true)
+  })
+
+  it('setup script is executable (has shebang)', () => {
+    const content = readFileSync(SETUP_SCRIPT_PATH, 'utf-8')
+    expect(content.startsWith('#!/')).toBe(true)
+  })
+
+  it('setup script has executable permissions', () => {
+    const stat = statSync(SETUP_SCRIPT_PATH)
+    const isExecutable = (stat.mode & 0o111) !== 0
+    expect(isExecutable).toBe(true)
+  })
+
+  it('setup script installs superpowers from marketplace', () => {
+    const content = readFileSync(SETUP_SCRIPT_PATH, 'utf-8')
+    expect(content).toMatch(/superpowers/)
+    expect(content).toMatch(/marketplace/)
+  })
+
+  it('setup script is idempotent (checks if already installed)', () => {
+    const content = readFileSync(SETUP_SCRIPT_PATH, 'utf-8')
+    expect(content).toMatch(/already|installed|skip|check/i)
+  })
+
+  it('superpowers integration rules file exists', () => {
+    expect(existsSync(SUPERPOWERS_RULES_PATH)).toBe(true)
+  })
+
+  it('superpowers rules have valid YAML frontmatter', () => {
+    const content = readFileSync(SUPERPOWERS_RULES_PATH, 'utf-8')
+    const frontmatterMatch = content.match(/^---\n([\s\S]*?)\n---/)
+    expect(frontmatterMatch, 'must have YAML frontmatter').not.toBeNull()
+    const frontmatter = frontmatterMatch![1]!
+    expect(frontmatter).toContain('paths:')
+  })
+
+  it('superpowers rules document integration with existing automation', () => {
+    const content = readFileSync(SUPERPOWERS_RULES_PATH, 'utf-8')
+    expect(content).toMatch(/implement-issue/i)
+    expect(content).toMatch(/automation|automated/i)
+  })
+
+  it('superpowers rules address retrospection/continuous improvement', () => {
+    const content = readFileSync(SUPERPOWERS_RULES_PATH, 'utf-8')
+    expect(content).toMatch(/retrospection|continuous improvement/i)
+  })
+})
+
+describe('implement-from-issue workflow includes superpowers setup', () => {
+  const workflowContent = readFileSync(WORKFLOW_PATH, 'utf-8')
+
+  it('workflow ensures superpowers plugin is available before running Claude', () => {
+    expect(workflowContent).toMatch(/superpowers|setup-superpowers/i)
+  })
+})
+
+describe('RUNNER_SETUP.md documents superpowers', () => {
+  const runnerSetup = readFileSync(join(__dirname, '../../.github/RUNNER_SETUP.md'), 'utf-8')
+
+  it('documents superpowers plugin installation', () => {
+    expect(runnerSetup).toMatch(/superpowers/i)
+  })
+})
+
 describe('pre-reset-retrospection.sh calls fetch-weekly-reset.sh', () => {
   it('calls fetch-weekly-reset.sh to auto-update config before time window check', () => {
     const content = readFileSync(RETROSPECTION_SCRIPT_PATH, 'utf-8')


### PR DESCRIPTION
## Summary
- Integrates the [Superpowers framework](https://github.com/obra/superpowers) as a Claude Code plugin that complements the existing `/implement-issue` workflow
- Adds idempotent setup script (`.claude/scripts/setup-superpowers.sh`), integration rules (`.claude/rules/superpowers-integration.md`), and auto-install step in the GitHub Actions workflow
- Documents how superpowers skills (brainstorming, planning, TDD, review) work alongside existing automation without conflicting

## Test plan
- [x] Unit tests pass (`npx vitest run tests/unit` — 116 tests including 11 new superpowers integration tests)
- [x] E2E tests pass (`npx playwright test` — 36 tests)
- [x] Type-check clean (`npx tsc --noEmit`)

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)