### PR TITLE
feat: increase retrospection window to 6 hours

### DIFF
--- a/.claude/scripts/retrospection-config.json
+++ b/.claude/scripts/retrospection-config.json
@@ -1,7 +1,7 @@
 {
   "resetDay": "Tuesday",
   "resetHourUTC": 0,
-  "windowHours": 2,
+  "windowHours": 6,
   "maxBudgetUsd": 5,
   "tasks": [
     "Fix any failing unit tests or type errors",

--- a/tests/unit/claudeRules.test.ts
+++ b/tests/unit/claudeRules.test.ts
@@ -361,7 +361,7 @@ describe('retrospection-config.json', () => {
     expect(typeof config.resetDay).toBe('string')
     expect(config.resetHourUTC).toBeGreaterThanOrEqual(0)
     expect(config.resetHourUTC).toBeLessThanOrEqual(23)
-    expect(config.windowHours).toBeGreaterThan(0)
+    expect(config.windowHours).toBe(6)
     expect(config.maxBudgetUsd).toBeGreaterThan(0)
     expect(Array.isArray(config.tasks)).toBe(true)
     expect(config.tasks.length).toBeGreaterThan(0)


### PR DESCRIPTION
## Summary
- Updated `windowHours` from 2 to 6 in retrospection config
- Retrospection now starts 6 hours before the weekly quota reset, giving more time for quality improvement tasks
- Added structural test asserting the exact window value

## Test plan
- [x] Unit tests pass (`npx vitest run tests/unit` — 162 passing)
- [x] Type-check clean (`npx tsc --noEmit`)

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)