### PR TITLE
fix: enforce domain purity, remove dead code, fix hook loading

### DIFF
--- a/.claude/rules/db-layer.md
+++ b/.claude/rules/db-layer.md
@@ -17,6 +17,7 @@ paths:
 
 Defined in `PUBLIC_DECK_CATALOG` (`src/domain/decks.ts`). To add a new public deck:
 1. Create `src/db/<name>SeedData.ts` exporting `SeedCard[]`
-2. Add entry to `PUBLIC_DECK_CATALOG` and `SEED_CARD_MAP` in `deckRepo.ts`
+2. Add entry to `PUBLIC_DECK_CATALOG` in `decks.ts` (with hardcoded `cardCount`) and `SEED_CARD_MAP` in `deckRepo.ts`
+3. A structural test verifies that `cardCount` in the catalog matches the actual seed data size
 
 `installPublicDeck()` is the canonical pattern for StrictMode-safe idempotent effects.

--- a/.claude/rules/domain-layer.md
+++ b/.claude/rules/domain-layer.md
@@ -5,7 +5,9 @@ paths:
 
 # Domain Layer Rules
 
-Pure functions only — zero imports from `db/` or `hooks/`.
+Pure functions only — zero imports from `db/` or `hooks/`. Enforced by structural test.
+
+`PUBLIC_DECK_CATALOG` uses hardcoded `cardCount` values (not derived from seed data imports). A structural test verifies counts match actual seed data.
 
 ## ts-fsrs API
 

--- a/.claude/scripts/retrospection-config.json
+++ b/.claude/scripts/retrospection-config.json
@@ -5,9 +5,9 @@
   "maxBudgetUsd": 5,
   "tasks": [
     "Fix any failing unit tests or type errors",
-    "Remove dead code and unused imports",
+    "Audit for new architectural violations not yet covered by structural tests",
     "Audit dependencies for updates",
     "Improve test coverage for uncovered domain functions",
-    "Refactor overly complex functions"
+    "Review and update MEMORY.md for stale or redundant lessons"
   ]
 }

--- a/.claude/skills/implement-issue/SKILL.md
+++ b/.claude/skills/implement-issue/SKILL.md
@@ -60,6 +60,7 @@ This is non-negotiable. Tests define the contract; implementation satisfies it.
 - **UI/flow changes** → E2E scenario in `tests/e2e/flashcards.spec.ts`
 - **Both** if the change spans layers
 - **Pure style/CSS changes** — not exempt. Write at least one E2E test asserting a behavioral property of the affected element: an attribute (`title`, `aria-label`, `disabled`), visibility, or role. If a change is truly behavior-free (e.g. a color value), write a minimal smoke test that exercises the affected element so future regressions are caught. "There's nothing to test" is almost never true — a missing `title` attribute on a disabled button is a behavioral gap that an E2E test can catch.
+- **Retrospection/audit issues** — convert findings into structural tests in `claudeRules.test.ts`. The "failing tests" are the structural tests that detect the violations; the "implementation" is fixing the violations so the tests pass. This is TDD — just with structural assertions instead of behavior assertions.
 
 Run to confirm they fail (passing tests at this stage means the feature already exists or the test is wrong):
 ```bash

--- a/.claude/skills/implement-issue/SKILL.md
+++ b/.claude/skills/implement-issue/SKILL.md
@@ -100,7 +100,7 @@ git add src/domain/... tests/unit/... # etc. — include .claude/skills/ changes
 git commit -m "$(cat <<'EOF'
 feat: <what changed and why in one sentence>
 
-Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
 EOF
 )"
 ```

--- a/.claude/skills/spaced-learning-guide/SKILL.md
+++ b/.claude/skills/spaced-learning-guide/SKILL.md
@@ -74,14 +74,13 @@ src/
     cards.ts        # createCard(front, back, deckId): Card — validates, generates UUID+timestamp
     scheduler.ts    # createNewSchedule(), getNextSchedule(fsrsCard, rating, now)
   db/               # Dexie side-effects (impure)
-    db.ts           # Dexie instance + schema (decks + cards + schedules tables, v3)
-    deckRepo.ts     # addDeck, getAllDecks, deleteDeck, ensureDefaultDeck
-    cardRepo.ts     # addCard, getAllCards, getCardsByDeck, deleteCard
+    db.ts           # Dexie instance + schema (decks + cards + schedules tables, v5)
+    deckRepo.ts     # addDeck, deleteDeck, archiveDeck, installPublicDeck, etc.
+    cardRepo.ts     # addCard, updateCard, deleteCard, getCardSnapshot, restoreCard
     reviewRepo.ts   # getSchedule, upsertSchedule, getDueCards, getDueCardsByDeck, getReviewedTodayCount
   hooks/            # React hooks bridging domain + db to UI
-    useCards.ts     # useLiveQuery → all cards
-    useDueCards.ts  # useLiveQuery → cards with due <= now
-    useDecks.ts     # useDeckStats() → [{deck, dueCount, totalCount}], useDecks() → Deck[]
+    useCards.ts     # useLiveQuery → cards by deck or all
+    useDecks.ts     # useDeckStats(), useArchivedDecks(), useUninstalledPublicDeckIds()
     useReview.ts    # review session state machine (reveal, rate); accepts optional deckId
     useReviewedToday.ts  # count of cards reviewed today
   components/       # Thin UI shells, minimal logic
@@ -134,20 +133,22 @@ type Rating = 'again' | 'hard' | 'good' | 'easy'
 
 ---
 
-## DB schema (Dexie v4, version 3)
+## DB schema (Dexie v4, version 5)
 
 ```typescript
 // db/db.ts — current schema
-db.version(3).stores({
-  decks:     'id, createdAt',
+db.version(5).stores({
+  decks:     'id, createdAt, status',
   cards:     'id, createdAt, deckId',   // keyed by UUID string
   schedules: 'cardId, due, state, last_review',  // keyed by cardId
 })
 ```
 
 **Migration notes:**
-- v3 upgrade creates a "Default" deck and backfills `deckId` on all pre-existing cards.
-- `ensureDefaultDeck()` in `deckRepo.ts` is called from `App.tsx` on mount to seed the Default deck for fresh installs (upgrade callbacks don't run on new DBs).
+- v3: creates "Default" deck and backfills `deckId` on all pre-existing cards.
+- v4: adds `status` index to decks, sets all existing decks to `'active'`.
+- v5: backfills `explanation` field on existing public deck cards by matching `front` text to seed data.
+- Dexie upgrade callbacks don't run on fresh installs — always call seed functions on app startup too.
 - When bumping schema, always carry forward all previous index definitions unchanged.
 
 `ScheduleRecord` stores all FSRS fields as flat numbers (dates as `.getTime()` timestamps).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ Three Dexie tables (schema version 5). See `src/db/db.ts` for full definitions.
 
 ## Tests
 
-Unit tests cover `src/domain/` only. E2E tests cover full user flows in Chromium. Structural tests in `claudeRules.test.ts` enforce best practices (rules, hooks, workflow config).
+Unit tests cover `src/domain/` only. E2E tests cover full user flows in Chromium. Structural tests in `claudeRules.test.ts` enforce architecture (domain purity, no dead exports, hook loading patterns, skill doc accuracy, workflow config).
 
 See `.claude/rules/e2e-testing.md` for Playwright-specific patterns and pitfalls.
 

--- a/src/components/DeckList.tsx
+++ b/src/components/DeckList.tsx
@@ -30,10 +30,11 @@ interface UndoState {
 export const DeckList = ({ onOpenDeck, onReviewDeck }: Props) => {
   const deckStatsRaw = useDeckStats()
   const archivedDecksRaw = useArchivedDecks()
-  const isLoading = deckStatsRaw === undefined || archivedDecksRaw === undefined
+  const uninstalledIdsRaw = useUninstalledPublicDeckIds()
+  const isLoading = deckStatsRaw === undefined || archivedDecksRaw === undefined || uninstalledIdsRaw === undefined
   const deckStats = deckStatsRaw ?? []
   const archivedDecks = archivedDecksRaw ?? []
-  const uninstalledIds = useUninstalledPublicDeckIds()
+  const uninstalledIds = uninstalledIdsRaw ?? new Set<string>()
   const [newName, setNewName] = useState('')
   const [error, setError] = useState('')
   const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null)

--- a/src/components/ReviewSession.tsx
+++ b/src/components/ReviewSession.tsx
@@ -67,7 +67,7 @@ export const ReviewSession = ({ deckId }: Props = {}) => {
       <div aria-busy="false" style={{ textAlign: 'center', padding: '40px' }}>
         <h2>All done!</h2>
         <p>No cards due for review. Great work!</p>
-        {reviewedToday > 0 && (
+        {reviewedToday !== undefined && reviewedToday > 0 && (
           <p style={{ color: '#888' }}>Reviewed today: {reviewedToday}</p>
         )}
       </div>
@@ -78,7 +78,7 @@ export const ReviewSession = ({ deckId }: Props = {}) => {
     <div aria-busy="false" style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
       <div style={{ display: 'flex', justifyContent: 'space-between', color: '#aaa' }}>
         <span>{remaining} card{remaining !== 1 ? 's' : ''} remaining</span>
-        {reviewedToday > 0 && <span>Reviewed today: {reviewedToday}</span>}
+        {reviewedToday !== undefined && reviewedToday > 0 && <span>Reviewed today: {reviewedToday}</span>}
       </div>
 
       <div

--- a/src/db/cardRepo.ts
+++ b/src/db/cardRepo.ts
@@ -3,12 +3,6 @@ import type { Card } from '../domain/types'
 
 export const addCard = (card: Card): Promise<string> => db.cards.add(card)
 
-export const getAllCards = (): Promise<Card[]> =>
-  db.cards.orderBy('createdAt').toArray()
-
-export const getCardsByDeck = (deckId: string): Promise<Card[]> =>
-  db.cards.where('deckId').equals(deckId).sortBy('createdAt')
-
 export const updateCard = (card: Card): Promise<string> => db.cards.put(card)
 
 export const deleteCard = async (id: string): Promise<void> => {

--- a/src/db/deckRepo.ts
+++ b/src/db/deckRepo.ts
@@ -75,9 +75,6 @@ export const permanentlyDeleteDeck = async (id: string): Promise<void> => {
   })
 }
 
-// Keep the old name as an alias for backward compatibility
-export const deleteDeck = permanentlyDeleteDeck
-
 // ── Snapshot / Restore (for undo) ────────────────────────────────────────────────
 
 /** Captures deck + all its cards + their schedules before deletion, for undo. */

--- a/src/db/deckRepo.ts
+++ b/src/db/deckRepo.ts
@@ -9,9 +9,6 @@ import { FOOD_SEED_CARDS } from './foodSeedData'
 
 export const addDeck = (deck: Deck): Promise<string> => db.decks.add(deck)
 
-export const getAllDecks = (): Promise<Deck[]> =>
-  db.decks.orderBy('createdAt').toArray()
-
 export const DEFAULT_DECK_ID = 'default-vietnamese-deck'
 export const YOGA_DECK_ID = 'default-yoga-deck'
 export const SENTENCES_DECK_ID = 'default-sentences-deck'

--- a/src/domain/decks.ts
+++ b/src/domain/decks.ts
@@ -1,8 +1,4 @@
 import type { Deck, PublicDeckDefinition } from './types'
-import { VIETNAMESE_SEED_CARDS } from '../db/seedData'
-import { YOGA_SEED_CARDS } from '../db/yogaSeedData'
-import { SENTENCES_SEED_CARDS } from '../db/sentencesSeedData'
-import { FOOD_SEED_CARDS } from '../db/foodSeedData'
 
 export class DeckValidationError extends Error {
   constructor(message: string) {
@@ -23,29 +19,29 @@ export const createDeck = (name: string): Deck => {
   }
 }
 
-export const PUBLIC_DECK_CATALOG: PublicDeckDefinition[] = [
+export const PUBLIC_DECK_CATALOG: readonly PublicDeckDefinition[] = [
   {
     id: 'default-vietnamese-deck',
     name: '1000 most common words in Vietnamese',
     description: 'Learn the most frequently used Vietnamese words with English translations.',
-    cardCount: VIETNAMESE_SEED_CARDS.length,
+    cardCount: 1000,
   },
   {
     id: 'default-yoga-deck',
     name: 'Vietnamese yoga vocabulary',
     description: 'Phrases an instructor or student might say in a yoga class, in Vietnamese.',
-    cardCount: YOGA_SEED_CARDS.length,
+    cardCount: 256,
   },
   {
     id: 'default-sentences-deck',
     name: '100 everyday Vietnamese sentences',
     description: 'Common sentences for daily conversations, shopping, dining, and getting around.',
-    cardCount: SENTENCES_SEED_CARDS.length,
+    cardCount: 100,
   },
   {
     id: 'default-food-deck',
     name: 'Vietnamese food & dining',
     description: 'Dishes, ingredients, cooking terms, and restaurant phrases for food lovers.',
-    cardCount: FOOD_SEED_CARDS.length,
+    cardCount: 163,
   },
 ]

--- a/src/hooks/useDecks.ts
+++ b/src/hooks/useDecks.ts
@@ -35,17 +35,13 @@ export const useArchivedDecks = (): Deck[] | undefined =>
     [],
   )
 
-export const useUninstalledPublicDeckIds = (): Set<string> => {
+export const useUninstalledPublicDeckIds = (): Set<string> | undefined => {
   const ids = useLiveQuery(
     async () => {
       const uninstalled = await db.decks.where('status').equals('uninstalled').toArray()
       return uninstalled.map((d) => d.id)
     },
     [],
-    [] as string[],
-  ) ?? []
-  return new Set(ids)
+  )
+  return ids ? new Set(ids) : undefined
 }
-
-export const useDecks = (): Deck[] =>
-  useLiveQuery(() => db.decks.orderBy('createdAt').toArray(), [], []) ?? []

--- a/src/hooks/useDueCards.ts
+++ b/src/hooks/useDueCards.ts
@@ -1,6 +1,0 @@
-import { useLiveQuery } from 'dexie-react-hooks'
-import { getDueCards } from '../db/reviewRepo'
-import type { Card } from '../domain/types'
-
-export const useDueCards = (): Card[] =>
-  useLiveQuery(() => getDueCards(), [], []) ?? []

--- a/src/hooks/useReviewedToday.ts
+++ b/src/hooks/useReviewedToday.ts
@@ -1,5 +1,5 @@
 import { useLiveQuery } from 'dexie-react-hooks'
 import { getReviewedTodayCount } from '../db/reviewRepo'
 
-export const useReviewedToday = (): number =>
-  useLiveQuery(() => getReviewedTodayCount(), [], 0) ?? 0
+export const useReviewedToday = (): number | undefined =>
+  useLiveQuery(() => getReviewedTodayCount(), [])

--- a/tests/unit/claudeRules.test.ts
+++ b/tests/unit/claudeRules.test.ts
@@ -1150,6 +1150,31 @@ describe('hooks must not mask loading state', () => {
   })
 })
 
+describe('interfaces enforce readonly fields', () => {
+  const checkReadonlyFields = (filePath: string, fileName: string) => {
+    const content = readFileSync(filePath, 'utf-8')
+    const interfaceBlocks = content.match(/(?:export\s+)?interface\s+\w+\s*\{[^}]+\}/g) ?? []
+    for (const block of interfaceBlocks) {
+      const name = block.match(/interface\s+(\w+)/)?.[1] ?? 'unknown'
+      const fieldLines = block.split('\n').filter(line => /^\s+\w+[?]?:/.test(line))
+      for (const field of fieldLines) {
+        expect(field.trim(), `${fileName}:${name} field missing readonly: ${field.trim()}`).toMatch(/^readonly\s/)
+      }
+    }
+    return interfaceBlocks.length
+  }
+
+  it('all interface fields in domain/types.ts use readonly', () => {
+    const count = checkReadonlyFields(join(__dirname, '../../src/domain/types.ts'), 'types.ts')
+    expect(count).toBeGreaterThan(0)
+  })
+
+  it('ScheduleRecord in db/db.ts uses readonly fields', () => {
+    const count = checkReadonlyFields(join(__dirname, '../../src/db/db.ts'), 'db.ts')
+    expect(count).toBeGreaterThan(0)
+  })
+})
+
 describe('skill documentation consistency', () => {
   it('implement-issue co-author matches current model (Opus 4.6)', () => {
     const skillContent = readFileSync(SKILL_PATH, 'utf-8')

--- a/tests/unit/claudeRules.test.ts
+++ b/tests/unit/claudeRules.test.ts
@@ -1025,3 +1025,144 @@ describe('e2e-testing.md covers known pitfalls', () => {
     expect(e2eRules).toMatch(/waitForTimeout|wait.*ms|1000/i)
   })
 })
+
+describe('PUBLIC_DECK_CATALOG cardCount matches actual seed data', () => {
+  it('every catalog entry has correct cardCount', async () => {
+    const { PUBLIC_DECK_CATALOG } = await import('../../src/domain/decks')
+    const { VIETNAMESE_SEED_CARDS } = await import('../../src/db/seedData')
+    const { YOGA_SEED_CARDS } = await import('../../src/db/yogaSeedData')
+    const { SENTENCES_SEED_CARDS } = await import('../../src/db/sentencesSeedData')
+    const { FOOD_SEED_CARDS } = await import('../../src/db/foodSeedData')
+
+    const expectedCounts: Record<string, number> = {
+      'default-vietnamese-deck': VIETNAMESE_SEED_CARDS.length,
+      'default-yoga-deck': YOGA_SEED_CARDS.length,
+      'default-sentences-deck': SENTENCES_SEED_CARDS.length,
+      'default-food-deck': FOOD_SEED_CARDS.length,
+    }
+
+    for (const entry of PUBLIC_DECK_CATALOG) {
+      const expected = expectedCounts[entry.id]
+      expect(expected, `Unknown deck ID in catalog: ${entry.id}`).toBeDefined()
+      expect(entry.cardCount, `${entry.name} cardCount mismatch`).toBe(expected)
+    }
+  })
+})
+
+describe('domain layer purity — no imports from db/ or hooks/', () => {
+  const domainDir = join(__dirname, '../../src/domain')
+  const domainFiles = readdirSync(domainDir).filter(f => f.endsWith('.ts'))
+
+  for (const file of domainFiles) {
+    it(`${file} has no imports from '../db/' or '../hooks/'`, () => {
+      const content = readFileSync(join(domainDir, file), 'utf-8')
+      const importLines = content.split('\n').filter(line => /^\s*import\s/.test(line))
+      for (const line of importLines) {
+        expect(line, `${file} violates domain purity: ${line.trim()}`).not.toMatch(/from\s+['"]\.\.\/db\//)
+        expect(line, `${file} violates domain purity: ${line.trim()}`).not.toMatch(/from\s+['"]\.\.\/hooks\//)
+      }
+    })
+  }
+})
+
+describe('no dead exports in repo layer', () => {
+  it('cardRepo.ts does not export getAllCards (removed as dead code)', () => {
+    const content = readFileSync(join(__dirname, '../../src/db/cardRepo.ts'), 'utf-8')
+    expect(content).not.toMatch(/export\s+(const|function)\s+getAllCards/)
+  })
+
+  it('cardRepo.ts does not export getCardsByDeck (removed as dead code)', () => {
+    const content = readFileSync(join(__dirname, '../../src/db/cardRepo.ts'), 'utf-8')
+    expect(content).not.toMatch(/export\s+(const|function)\s+getCardsByDeck/)
+  })
+
+  it('deckRepo.ts does not export getAllDecks (removed as dead code)', () => {
+    const content = readFileSync(join(__dirname, '../../src/db/deckRepo.ts'), 'utf-8')
+    expect(content).not.toMatch(/export\s+(const|function)\s+getAllDecks/)
+  })
+
+  it('useDueCards.ts does not exist (removed as dead code)', () => {
+    expect(existsSync(join(__dirname, '../../src/hooks/useDueCards.ts'))).toBe(false)
+  })
+})
+
+describe('hooks must not mask loading state', () => {
+  const hooksDir = join(__dirname, '../../src/hooks')
+  const hookFiles = readdirSync(hooksDir).filter(f => f.endsWith('.ts'))
+
+  it('no exported hook uses ?? [] to mask undefined loading state', () => {
+    for (const file of hookFiles) {
+      const content = readFileSync(join(hooksDir, file), 'utf-8')
+      // Find exported functions that use ?? [] anywhere in their body
+      // Match export const ... = ... ?? []  across multiple lines
+      const exportBlocks = content.match(/export\s+const\s+\w+[\s\S]*?(?=\nexport\s|\n\n|$)/g) ?? []
+      for (const block of exportBlocks) {
+        if (/\?\?\s*\[\]/.test(block)) {
+          const name = block.match(/export\s+const\s+(\w+)/)?.[1] ?? 'unknown'
+          expect.fail(`${file}: exported hook '${name}' masks loading state with ?? []`)
+        }
+      }
+    }
+  })
+
+  it('no hook passes a third argument (default value) to useLiveQuery', () => {
+    for (const file of hookFiles) {
+      const content = readFileSync(join(hooksDir, file), 'utf-8')
+      // Match useLiveQuery calls and extract the full call text
+      const calls = [...content.matchAll(/useLiveQuery\(/g)]
+      for (const call of calls) {
+        const startIdx = call.index! + call[0].length
+        // Extract balanced call content
+        let depth = 1
+        let endIdx = startIdx
+        for (let i = startIdx; i < content.length && depth > 0; i++) {
+          const ch = content[i]
+          if (ch === '(' || ch === '[' || ch === '{') depth++
+          else if (ch === ')' || ch === ']' || ch === '}') {
+            depth--
+            if (depth === 0) endIdx = i
+          }
+        }
+        const callContent = content.slice(startIdx, endIdx)
+        // Count top-level commas (depth=0 relative to the call args)
+        let argDepth = 0
+        let commaCount = 0
+        for (const ch of callContent) {
+          if (ch === '(' || ch === '[' || ch === '{') argDepth++
+          else if (ch === ')' || ch === ']' || ch === '}') argDepth--
+          else if (ch === ',' && argDepth === 0) commaCount++
+        }
+        // Check if last non-whitespace before closing paren is a comma (trailing comma)
+        const trimmed = callContent.trimEnd()
+        const hasTrailingComma = trimmed.endsWith(',')
+        const actualArgs = hasTrailingComma ? commaCount : commaCount + 1
+        // useLiveQuery(fn, deps) = 2 args; useLiveQuery(fn, deps, default) = 3 args
+        if (actualArgs >= 3) {
+          expect.fail(`${file}: useLiveQuery called with ${actualArgs} args (provides a default value, masking loading state)`)
+        }
+      }
+    }
+  })
+})
+
+describe('skill documentation consistency', () => {
+  it('implement-issue co-author matches current model (Opus 4.6)', () => {
+    const skillContent = readFileSync(SKILL_PATH, 'utf-8')
+    const coAuthorMatch = skillContent.match(/Co-Authored-By:\s*Claude\s+(\w+)\s+([\d.]+)/)
+    expect(coAuthorMatch, 'skill must have a Co-Authored-By line').not.toBeNull()
+    // Should use the model actually running (Opus 4.6), not an outdated one
+    expect(coAuthorMatch![1]).toBe('Opus')
+    expect(coAuthorMatch![2]).toBe('4.6')
+  })
+
+  it('spaced-learning-guide schema version matches actual db.ts version', () => {
+    const guideSkillPath = join(__dirname, '../../.claude/skills/spaced-learning-guide/SKILL.md')
+    if (!existsSync(guideSkillPath)) return // skip if skill doesn't exist
+    const guideContent = readFileSync(guideSkillPath, 'utf-8')
+    const dbTs = readFileSync(join(__dirname, '../../src/db/db.ts'), 'utf-8')
+    const versions = [...dbTs.matchAll(/db\.version\((\d+)\)/g)].map(m => parseInt(m[1]!, 10))
+    const maxVersion = Math.max(...versions)
+    // Guide should reference the current version
+    expect(guideContent, `spaced-learning-guide references wrong schema version (should be v${maxVersion})`).toMatch(new RegExp(`version ${maxVersion}|v${maxVersion}`))
+  })
+})

--- a/tests/unit/claudeRules.test.ts
+++ b/tests/unit/claudeRules.test.ts
@@ -1081,6 +1081,11 @@ describe('no dead exports in repo layer', () => {
     expect(content).not.toMatch(/export\s+(const|function)\s+getAllDecks/)
   })
 
+  it('deckRepo.ts does not export deleteDeck alias (removed backward-compat shim)', () => {
+    const content = readFileSync(join(__dirname, '../../src/db/deckRepo.ts'), 'utf-8')
+    expect(content).not.toMatch(/export\s+const\s+deleteDeck\b/)
+  })
+
   it('useDueCards.ts does not exist (removed as dead code)', () => {
     expect(existsSync(join(__dirname, '../../src/hooks/useDueCards.ts'))).toBe(false)
   })


### PR DESCRIPTION
## Summary
- **Domain layer purity**: Removed `src/domain/decks.ts` → `src/db/` imports (violated "pure functions only" rule). `PUBLIC_DECK_CATALOG` now uses hardcoded card counts with a structural test ensuring they match actual seed data.
- **Dead code removal**: Deleted unused `useDueCards` hook, `useDecks` hook, `getAllCards`, `getCardsByDeck`, `getAllDecks` exports.
- **Hook loading-state compliance**: Fixed `useUninstalledPublicDeckIds` and `useReviewedToday` to return `T | undefined` instead of masking loading state with defaults. Updated consuming components to handle undefined.
- **Skill docs**: Fixed implement-issue co-author (Sonnet → Opus), updated spaced-learning-guide schema version (v3 → v5).
- **13 new structural tests** enforcing: domain import purity, no dead exports, hook loading patterns, catalog cardCount accuracy, and skill documentation consistency.

## Test plan
- [x] Unit tests pass (186 tests, `npx vitest run tests/unit`)
- [x] E2E tests pass (40 tests, `npx playwright test`)
- [x] Type-check clean (`npx tsc --noEmit`)

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)